### PR TITLE
docs: 完善安装与项目关联引导

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ goalboard install
 
 打开 `http://127.0.0.1:4173` 后，可以在设置中创建、导入、改名和打开项目，也可以先配置 Codex / Claude Code 接入。选择一个项目只改变网页浏览位置，不会自动绑定或切换当前 Runtime Session；已有旧 DB 只有明确选择并确认后才会迁入项目。
 
+> **注意**：`goalboard-web` 是前台进程，**请保持运行它的终端窗口开启**——关闭终端会同时关闭前端。临时体验也可以这样后台启动：
+>
+> ```bash
+> nohup "$HOME/.goalboard/bin/goalboard-web" --home "$HOME/.goalboard" >/tmp/goalboard-web.log 2>&1 &
+> ```
+>
+> 更稳定的常驻方案（LaunchAgent、`goalboard web --detach`）在规划中；需要随时重启网页服务的，也可以直接重新运行上面任一条命令。
+
 ### 安装边界
 
 `goalboard install` 只维护 `~/.goalboard`：版本化程序与共享 Skill、MCP/Web/CLI 启动入口、项目 DB 根目录、日志和安装清单。它不会创建或启动项目，不会写入用户项目，也不会修改任何 Runtime 的用户级配置。之后若要把 MCP 入口注册到某个 Runtime，必须走用户确认的 Runtime 集成流程。
@@ -79,6 +87,8 @@ goalboard install
 `goalboard install` 只完成 GoalBoard 本体安装，默认输出安装位置、CLI/MCP/Web 启动器和安全边界；自动化可以使用 `goalboard install --json`。安装不会顺带创建项目、关联 Session、启动服务或修改 Runtime 配置。
 
 安装后的 Runtime 接入由同一领域服务完成。当前 adapter 会只读探测 Codex 和 Claude Code，并先生成包含配置路径、GoalBoard MCP entry、Skill 链接、备份位置和重启说明的预览；只有用户对当前 Runtime 和当前 plan 明确确认后才会写入。MCP 与 Skill 作为一个事务验证，失败会恢复原配置字节和原 Skill 状态。移除时只撤销 GoalBoard ownership receipt 记录且仍未被用户改写的内容。未知同名配置或 Skill 会显示冲突，不会被覆盖。
+
+接入确认完成后，**必须重开 Codex / Claude Code 会话**才会生效（MCP 和 Skill 配置只在启动时加载）。重启后明确说「继续用 GoalBoard」**并指定要关联的项目**（例如「关联『把 GoalBoard V1 做成可用产品』」）——Runtime 不会自动关联项目，必须等你的明确指令。接入预览界面会逐条展示改动内容和重启提示，安装输出也会给出同样的说明。
 
 项目创建和当前 Session 关联是独立操作：用户在当前 Runtime 调用统一 Skill 后，Skill 使用 `context-list-projects`、`context-bind` 或 `context-create-and-bind`，并且只在用户明确选择后写入 GoalBoard 自己的项目目录。Web 可创建、导入、改名和打开项目，也可管理已经确认过的 Session 关联；网页中的项目选择本身不会改变 Runtime Session 绑定，新 Session 仍要先在对应 Runtime 对话里询问并确认。
 

--- a/skills/goal-advance/SKILL.md
+++ b/skills/goal-advance/SKILL.md
@@ -48,6 +48,12 @@ This checkpoint is editable, not a verdict. User-confirmed facts, project facts,
 
 ## 1. Explicitly resolve the current project
 
+用户刚完成安装、重开 Session 后第一次提到 GoalBoard 时，先用一两句话说明关联规则，再开始解析：
+
+- “GoalBoard 已经装好了。接下来需要你在对话里明确说‘用 GoalBoard / 关联某项目’，我才会建立项目关联——我不会自动关联，也不会从目录或历史记录猜测。”
+- 如果用户只说“装好了”“试试看”或“接着搞”，先请他给出明确指令：使用 GoalBoard、关联指定项目，或新建项目。
+- 用户给出明确指令后，再按下面的解析流程走；在此之前不调用任何绑定或创建工具。
+
 At the beginning of a user-invoked GoalBoard flow, call `goalboard_v1_context_resolve`.
 
 - If the result is `bound`, use the returned connection and `board_id`. Do not substitute another Board or database.
@@ -72,6 +78,27 @@ When the user explicitly asks to manage projects, stay in this same conversation
 - To delete a managed project, first identify the exact named project and ask a separate, unmistakable confirmation that its GoalBoard data should be erased. Only then call `goalboard_v1_project_delete` with `delete_confirmed=true` and a fresh `idempotency_key`. It rejects a project with a valid Claim or unfinished Run, removes every binding only after the check, and never accepts a raw database path. Reuse the same key only to retry the same deletion; if its returned cleanup state is `pending`, report that cleanup has not yet finished and retry that exact request rather than reconnecting it.
 
 Do not treat “use another project”, “not this suggestion”, “stop using GoalBoard here”, and “delete this project” as the same consent. Switching uses the existing `context_bind` plus its separate `rebind_confirmed=true`; suggestion rejection, unbinding, and deletion have their own confirmations.
+
+### 1.1 项目关联提示模板
+
+每次需要用户决定项目关联时，用「一句现状 + 一个明确的问题」向用户说明，不展示数据库路径、`project_id` 或宿主原始线索。按场景套用下面的提示：
+
+| 场景 | 用户会看到的提示 |
+| --- | --- |
+| 有候选项目（`suggested`） | 「我找到一个可能相关的项目：{项目名}。它只是候选，还没有关联。要把当前会话关联到它吗？」只有用户明确说「用这个」后才调用 `context_bind` |
+| 多个候选 | 列出候选名后问「要关联哪一个？」一次只问一个决定 |
+| 没有候选（`unbound`，有项目列表） | 「当前会话还没有关联项目。现有项目：{列表}。要打开其中一个，还是新建一个？」 |
+| 用户选择已有项目 | 复述后确认：「好，把当前会话关联到「{项目名}」，可以吗？」用户明确同意后才调用 `context_bind` |
+| 用户要新建项目 | 先问「新建项目叫什么名字？」，拿到名字后复述并确认「创建项目「{名字}」并关联当前会话？」 |
+| 用户说「就新建当前这个/直接用当前目录」 | 用宿主工作目录名生成默认项目名（例如当前目录 `pet-app` 提议《pet-app》），复述「把当前目录新建为项目《pet-app》并关联当前会话，可以吗？」，用户明确同意后才调用 `context_create_and_bind` |
+| 已绑定 A，用户提到 B | 「当前会话关联的是「{A}」。要切换到「{B}」吗？」切换必须单独确认；「提到 B」不等于「要切换」 |
+| 用户拒绝候选 | 「好的，这个会话不再提示「{项目名}」，不会删除或隐藏它。」然后调用 `context_reject_suggestion` |
+| 用户要停用当前关联 | 「解除当前会话与「{项目名}」的关联，数据会保留。确认吗？」 |
+| 用户要删除项目 | 「删除项目「{项目名}」会清掉它的 GoalBoard 数据，且无法撤销；有未结束工作时系统会拒绝。确认删除吗？」 |
+
+不算确认：沉默、超时、「不是现在」「你看着办」和模糊表达都不是确认。只有用户在当前对话明确说出同意或拒绝，才能传 `user_confirmed=true`。
+
+不展示：数据库路径、`project_id`、宿主提供的原始线索（目录、仓库名、会话标题）。只展示用户可读的项目名和通用原因。
 
 ## 2. Route the user's request in the same conversation
 

--- a/src/install/home.ts
+++ b/src/install/home.ts
@@ -234,7 +234,7 @@ export async function installGoalBoardHome(
       launchers,
       next_steps: {
         message:
-          "GoalBoard 只完成了本体安装；没有创建项目，也没有修改 Runtime 配置或用户项目文件。Runtime 接入和项目设置必须通过后续单独的显式流程完成。",
+          "GoalBoard 只完成了本体安装；没有创建项目，也没有修改 Runtime 配置或用户项目文件。Runtime 接入和项目设置必须通过后续单独的显式流程完成。两个常见坑：goalboard-web 是前台进程，关掉运行它的终端窗口前端就会关闭；接入 Codex / Claude Code 后必须重开会话，MCP 和 Skill 才会生效。重开后在对话里明确说「继续用 GoalBoard」并告诉我关联哪个项目——Runtime 不会自动关联项目，必须等你的明确指令。",
         web_command: [launchers.web, "--home", homeDirectory],
       },
       written_paths: writtenPaths,

--- a/src/install/runtime-integration.ts
+++ b/src/install/runtime-integration.ts
@@ -198,7 +198,10 @@ const CODEX_ADAPTER: RuntimeAdapter = {
   inspectConfig: inspectCodexConfig,
   connectConfig: connectCodexConfig,
   removeConfig: removeCodexConfig,
-  restartInstructions: ["关闭并重新打开 Codex Session，使新的 MCP 和 Skill 配置生效。"],
+  restartInstructions: [
+    "关闭并重新打开 Codex Session（MCP 和 Skill 配置只在启动时加载，不重开不会生效）。",
+    "重启后明确说「继续用 GoalBoard」并指定要关联的项目（例如「关联『把 GoalBoard V1 做成可用产品』」）——Runtime 不会自动关联项目，必须等你的明确指令。",
+  ],
 };
 
 const CLAUDE_CODE_ADAPTER: RuntimeAdapter = {
@@ -215,7 +218,10 @@ const CLAUDE_CODE_ADAPTER: RuntimeAdapter = {
   inspectConfig: inspectClaudeConfig,
   connectConfig: connectClaudeConfig,
   removeConfig: removeClaudeConfig,
-  restartInstructions: ["关闭并重新打开 Claude Code Session，使新的 MCP 和 Skill 配置生效。"],
+  restartInstructions: [
+    "关闭并重新打开 Claude Code Session（MCP 和 Skill 配置只在启动时加载，不重开不会生效）。",
+    "重启后明确说「继续用 GoalBoard」并指定要关联的项目（例如「关联『把 GoalBoard V1 做成可用产品』」）——Runtime 不会自动关联项目，必须等你的明确指令。",
+  ],
 };
 
 const ADAPTERS: readonly RuntimeAdapter[] = [CODEX_ADAPTER, CLAUDE_CODE_ADAPTER];

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -833,7 +833,7 @@ const CONTEXT_TOOLS: McpToolDefinition[] = [
   {
     name: "goalboard_v1_context_resolve",
     description:
-      "由统一 GoalBoard Skill 显式解析当前 Runtime 宿主提供的稳定工作入口；未绑定时返回当前对话应让用户选择或创建项目的结果。",
+      "由统一 GoalBoard Skill 显式解析当前 Runtime 宿主提供的稳定工作入口；未绑定时返回当前对话应让用户选择或创建项目的结果。返回 suggested 时必须向用户展示候选项目名和通用原因并询问是否绑定；返回 unbound 时必须展示项目列表并询问选择或新建；任何情况下都不要自动绑定或猜测项目。",
     inputSchema: {
       type: "object",
       properties: {},
@@ -843,7 +843,7 @@ const CONTEXT_TOOLS: McpToolDefinition[] = [
   {
     name: "goalboard_v1_context_list_projects",
     description:
-      "列出 GoalBoard 自己管理的项目、当前 Runtime 工作入口状态及宿主建议；不暴露数据库路径，也不创建或修改绑定。",
+      "列出 GoalBoard 自己管理的项目、当前 Runtime 工作入口状态及宿主建议；不暴露数据库路径，也不创建或修改绑定。给用户展示时只显示项目名，不要展示 project_id 或数据库路径。",
     inputSchema: {
       type: "object",
       properties: {},
@@ -853,7 +853,7 @@ const CONTEXT_TOOLS: McpToolDefinition[] = [
   {
     name: "goalboard_v1_context_reject_suggestion",
     description:
-      "用户在当前 Runtime 对话明确拒绝一个宿主建议项目后，停止在当前 Session 重复建议它；不绑定、不删除项目，也不影响其他 Session。",
+      "用户在当前 Runtime 对话明确拒绝一个宿主建议项目后，停止在当前 Session 重复建议它；不绑定、不删除项目，也不影响其他 Session。user_confirmed=true 只能用于用户在当前对话明确说出拒绝（例如「不是这个」）；沉默、超时或含糊回答不能调用本工具。",
     inputSchema: {
       type: "object",
       properties: {
@@ -867,7 +867,7 @@ const CONTEXT_TOOLS: McpToolDefinition[] = [
   {
     name: "goalboard_v1_context_bind",
     description:
-      "用户在当前 Runtime 对话明确选择项目后，绑定当前宿主工作入口；已有不同绑定时还必须明确确认切换。",
+      "用户在当前 Runtime 对话明确选择项目后，绑定当前宿主工作入口；已有不同绑定时还必须明确确认切换。user_confirmed=true 只能用于用户在当前对话明确说出选择；切换项目必须先单独确认 rebind_confirmed=true，不能把「提到另一个项目」当成切换。",
     inputSchema: {
       type: "object",
       properties: {
@@ -882,7 +882,7 @@ const CONTEXT_TOOLS: McpToolDefinition[] = [
   {
     name: "goalboard_v1_context_unbind",
     description:
-      "用户在当前 Runtime 对话明确要求后，解除当前工作入口与项目的绑定；不会删除项目、数据库或其他 Runtime 的绑定。",
+      "用户在当前 Runtime 对话明确要求后，解除当前工作入口与项目的绑定；不会删除项目、数据库或其他 Runtime 的绑定。用户必须明确说出「解绑/停用」，不能把删除、切换项目或其他意图当作解绑。",
     inputSchema: {
       type: "object",
       properties: {
@@ -895,7 +895,7 @@ const CONTEXT_TOOLS: McpToolDefinition[] = [
   {
     name: "goalboard_v1_context_create_and_bind",
     description:
-      "用户在当前 Runtime 对话明确要求新建项目时，在 GoalBoard 自己的数据目录创建项目并绑定当前工作入口；不修改项目文件或 Runtime 配置。",
+      "用户在当前 Runtime 对话明确要求新建项目时，在 GoalBoard 自己的数据目录创建项目并绑定当前工作入口；不修改项目文件或 Runtime 配置。调用前必须先向用户复述项目名并取得明确确认。",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## 改动内容

- **安装输出**（home.ts）：补充 Web 前台进程保活提示、接入后必须重开会话、重开后需明确指令关联项目
- **接入重启提示**（runtime-integration.ts）：说明重启原因 + 重启后第一句（继续用 GoalBoard 并指定项目）
- **Skill 项目关联模板**（goal-advance/SKILL.md）：候选/选择/新建/按当前目录新建/切换/拒绝/解绑/删除 全场景提示；明确什么不算确认、不展示什么
- **MCP 关联工具描述**（server.ts）：六个 context 工具补充何时问、问什么、什么才算确认

## 验证

- pnpm typecheck 通过
- 安装 / Runtime 接入 / MCP 测试 32/32 通过