### PR TITLE
fix: implement resources/templates/list so MCP hosts can load the server

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1780,6 +1780,9 @@ export class GoalBoardServer {
     if (method === "resources/list") {
       return { jsonrpc: "2.0", id: msgId, result: { resources: [] } };
     }
+    if (method === "resources/templates/list") {
+      return { jsonrpc: "2.0", id: msgId, result: { resourceTemplates: [] } };
+    }
     return {
       jsonrpc: "2.0",
       id: msgId,

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -266,6 +266,30 @@ describe("mcp server", () => {
     assert.equal((result as { error: { code: number } }).error.code, -32601);
   });
 
+  it("serves empty resource and resource-template lists for clients that enumerate them", async () => {
+    const server = new GoalBoardServer();
+    const resources = await server.handleMessage({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/list",
+      params: {},
+    });
+    assert.deepEqual(
+      (resources as { result: { resources: unknown[] } }).result.resources,
+      [],
+    );
+    const templates = await server.handleMessage({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "resources/templates/list",
+      params: {},
+    });
+    assert.deepEqual(
+      (templates as { result: { resourceTemplates: unknown[] } }).result.resourceTemplates,
+      [],
+    );
+  });
+
   it("serves one filtered V1 Goal Contract with a stable Web URL", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "goalboard-mcp-v1-"));
     const databasePath = path.join(directory, "goalboard.db");


### PR DESCRIPTION
实现 MCP `resources/templates/list`，返回空模板列表。部分 MCP 宿主启动时会枚举资源模板，之前返回 method not found 会导致宿主认为服务加载失败。\n\n- src/mcp/server.ts：新增 `resources/templates/list` 空响应\n- tests/mcp.test.ts：覆盖 resources/list 与 resources/templates/list\n\n验证：pnpm typecheck 通过，MCP 测试通过