### PR TITLE
feat: make runtime Web startup persistent by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ pnpm install:local
 2. 在“设置 → Runtime”中选择 Codex 或 Claude Code，先看改动预览，再确认接入。
 3. **新开一个 Runtime Session**，说“继续用 GoalBoard”。Runtime 只在 Session 启动时读取 MCP 和 Skill，所以当前对话不会凭空出现刚安装的工具。
 
+接入生效后也可以直接对 Runtime 说“启动 GoalBoard”。它会先检查受管理的服务状态：macOS
+首次启用时会说明这是登录后自启、关闭终端后仍运行的用户级后台服务，并在你明确确认后安装；
+已经运行时只返回页面地址。只有明确说“临时打开 GoalBoard”，才会使用随当前终端或 Session
+结束的前台进程。非 macOS 目前没有系统级常驻服务，Runtime 会如实说明并询问是否临时打开。
+
 想从自己的想法开始时，不需要先在网页里填表。新 Session 接入后直接说：
 
 > 用 GoalBoard 新建一个项目，帮我把“让朋友第一次安装就能顺利用起来”澄清成 Goal Tree。
@@ -95,6 +100,24 @@ pnpm install:local
 ```
 
 这份项目在 catalog 中明确标记为 `regenerable_demo`，与 `user`、`migrated_user` 用户数据分开。重复创建会打开已有 demo；重建会清除 demo 内的改动；删除和普通卸载都只清理可再生 demo，不会碰用户项目。仓库开发和截图也可以继续使用 `examples/seed-demo.mts`，它调用的是同一套分类和重建逻辑。
+
+## 启动 Web：常驻或临时
+
+已经接入 GoalBoard Skill 的 Runtime 中，推荐直接说：
+
+> 启动 GoalBoard
+
+Runtime 会先只读检查 `goalboard service status`，不会直接拉起一个容易随 Session 消失的前台
+进程。macOS 上，未安装常驻服务时会先说明它将修改用户级 LaunchAgent、登录后自启且关闭终端
+后仍运行，得到明确确认后才安装；已停止时启动，已运行时只返回地址，旧配置则先说明修复内容再
+确认。服务命令会等到页面健康可访问后才报告成功。
+
+如果只想当前终端临时使用，请明确说：
+
+> 临时打开 GoalBoard
+
+这会运行前台 `goalboard-web`；终端或 Runtime Session 关闭后页面也会停止。非 macOS 当前只支持
+这种前台方式，不会用 `nohup` 或普通后台 shell 冒充系统级常驻服务。
 
 ## 开发与手动启动
 

--- a/skills/goal-advance/SKILL.md
+++ b/skills/goal-advance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-advance
-description: Use GoalBoard from the current Runtime conversation to connect a user-selected project, clarify a rough idea, choose available work, and keep evidence and decisions in the shared GoalBoard truth source.
+description: Use GoalBoard from the current Runtime conversation to start or temporarily open its local Web UI, connect a user-selected project, clarify a rough idea, choose available work, and keep evidence and decisions in the shared GoalBoard truth source. Use when the user explicitly asks to start, open, use, connect, create, continue, or advance GoalBoard.
 ---
 
 # GoalBoard Runtime
@@ -9,13 +9,21 @@ This is the one public GoalBoard entry for the Runtime currently talking with th
 
 The current Runtime stays in the current conversation. GoalBoard supplies shared state and atomic lifecycle operations through MCP; it does not open another Runtime, dispatch a separate Session, require a Web page, or edit the user's project files.
 
+## 0. Route an explicit request to start the Web UI
+
+Treat Web service management as a separate user-requested setup action, not as Goal work. When the user says “启动 GoalBoard” or “打开 GoalBoard”, first inspect the installed managed service. On macOS, prefer the user-level persistent service; it survives terminal or Runtime closure and starts again after login. Installing or repairing that persistent service changes the user's LaunchAgent configuration, so explain the effect and obtain explicit confirmation before the first install or a repair.
+
+Only use the foreground `goalboard-web` launcher when the user explicitly says “临时打开 GoalBoard”, or explicitly accepts that temporary option after being told persistent service is unavailable. Never use `nohup`, `&`, or another detached shell as a substitute for a supported service. Read [references/service-start.md](references/service-start.md) and follow its state table, commands, confirmations, and failure explanations.
+
+After a successful managed start, return `http://127.0.0.1:4173` only when the service command has confirmed the page health check. Starting Web does not select a project or authorize any Goal change; continue with project resolution only if the user also asked to use GoalBoard for project work.
+
 ## Non-negotiable boundaries
 
-- Use only the host-provided `goalboard_v1_*` Runtime MCP tools. Do not call the CLI, open SQLite directly, or use a management MCP tool as a fallback.
+- For every Goal lifecycle operation, use only the host-provided `goalboard_v1_*` Runtime MCP tools. Do not call the CLI, open SQLite directly, or use a management MCP tool as a fallback. The explicit Web service route above may use only the public `goalboard service` or foreground launcher commands described in its reference; that exception grants no Goal data access.
 - Every Goal lifecycle change goes through MCP. The only project setup write is an explicitly user-confirmed creation under GoalBoard's own `~/.goalboard` data directory; it does not write the user project or any Runtime configuration.
 - Goal 删除是可恢复的“移入回收站”，不是物理清除。只有用户在当前对话明确说要删除或恢复指定 Goal 时，才能传 `user_confirmed=true` 调用回收站写工具；“清理一下”“可能不需要”之类含糊说法先追问。
 - Never infer a project from Git, a directory, a repository name, a project name, or conversation text. Never invent a stable Runtime work-context ID or fabricate host clues. A host may return non-authoritative suggestions, but they are a question for the user, never a binding.
-- Web is optional. Do not proactively open it, ask the user to open it, or make it a prerequisite for project setup, clarification, execution, review, or recovery. Offer a returned Goal link only when the user asks to inspect the Board.
+- Web is optional. Do not proactively open it, ask the user to open it, or make it a prerequisite for project setup, clarification, execution, review, or recovery. An explicit user request to start or open Web follows section 0. Offer a returned Goal link only when the user asks to inspect the Board.
 - The Runtime may carry a user decision made in this conversation through `goalboard_v1_goal_tree_decide`. Set `user_confirmed=true` only after explicit user words and provide a faithful `confirmation_summary`; never invent a user identity, Session ID, message reference, or confirmation.
 
 `role` is only the kind of work that the current Runtime is doing for one MCP operation. It does not mean a different Runtime or a different Session must take over.

--- a/skills/goal-advance/agents/openai.yaml
+++ b/skills/goal-advance/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "GoalBoard Runtime"
-  short_description: "在当前对话自然澄清、选择并推进 GoalBoard 工作"
-  default_prompt: "Use $goal-advance in this conversation. Explain what you understand and what happens next in plain language, then persist and continue the current GoalBoard flow."
+  short_description: "启动 Web，并在当前对话澄清、选择和推进 GoalBoard 工作"
+  default_prompt: "Use $goal-advance in this conversation to start GoalBoard when requested, explain what happens next in plain language, and continue the current GoalBoard flow."

--- a/skills/goal-advance/references/service-start.md
+++ b/skills/goal-advance/references/service-start.md
@@ -1,0 +1,60 @@
+# Starting GoalBoard Web from a Runtime
+
+Use this reference only when the user explicitly asks to start or open GoalBoard Web. Service management is independent of Goal lifecycle; never use these commands to read or modify Goals, projects, bindings, Claims, Runs, or Evidence.
+
+## 1. Inspect before acting
+
+Run the installed, read-only status command first:
+
+```bash
+"$HOME/.goalboard/bin/goalboard" service status --home "$HOME/.goalboard" --json
+```
+
+If the launcher does not exist, say GoalBoard itself is not installed or is incomplete and point the user to the normal installation flow. Do not silently use a repository checkout, another database, or a different GoalBoard home.
+
+## 2. Route an ordinary “启动 GoalBoard” request
+
+Use the returned `state` exactly:
+
+| State | Runtime action |
+|---|---|
+| `running` | Do not restart. Say the page is already available and return `http://127.0.0.1:4173`. |
+| `absent` | Say: “这会安装 GoalBoard 的 macOS 用户级常驻后台服务。关闭终端后页面仍会运行，登录后会自动启动。要现在安装并启动吗？” Run `service install --confirm` only after an explicit yes in this conversation. |
+| `stopped` | The user's explicit “启动” already authorizes starting the existing owned service. Run `service start --confirm`; return the address only after success. |
+| `unhealthy` | Explain that the process exists but the page is unavailable. Run `service restart --confirm` under the user's explicit start request; return the address only after the health check succeeds. |
+| `needs_repair` | Explain that GoalBoard's owned LaunchAgent uses an old or incomplete configuration and that repair will rewrite that owned configuration and restart it. Obtain explicit confirmation, then run `service install --confirm`. |
+| `unavailable` | Explain the returned missing-launcher or incomplete-install message. Recommend repairing the GoalBoard installation; do not fall back to an unknown binary or service. |
+| `conflict` | Explain that the same LaunchAgent name is unknown or user-modified and GoalBoard will not overwrite it. Stop and let the user resolve ownership; do not force install or start. |
+| `unsupported` | Say that this operating system currently has no GoalBoard system-level persistent-service integration. Do not claim background startup. Ask whether the user wants to “临时打开 GoalBoard” in the foreground. |
+
+The persistent commands are:
+
+```bash
+"$HOME/.goalboard/bin/goalboard" service install --home "$HOME/.goalboard" --confirm --json
+"$HOME/.goalboard/bin/goalboard" service start --home "$HOME/.goalboard" --confirm --json
+"$HOME/.goalboard/bin/goalboard" service restart --home "$HOME/.goalboard" --confirm --json
+```
+
+Do not run `install --confirm` for `absent` or `needs_repair` until the required confirmation is present in the current conversation. Do not reinterpret “试试看”, silence, or an unrelated earlier approval as confirmation.
+
+## 3. Route an explicit temporary request
+
+“临时打开 GoalBoard” means foreground operation. First inspect status so a healthy persistent service is not given a competing process on the same port.
+
+- If managed state is `running`, return its address instead of starting a second server.
+- If an owned service process is running but unhealthy or needs repair, explain the conflict and use the controlled repair/restart route; do not start a second server on the same port.
+- Otherwise run the installed foreground launcher attached to the current terminal or Runtime process:
+
+```bash
+"$HOME/.goalboard/bin/goalboard-web" --home "$HOME/.goalboard"
+```
+
+Before launching, say plainly that closing the terminal or Runtime Session stops this temporary page. Keep the process in the foreground. Do not add `nohup`, `&`, `disown`, a background shell, or a claim that it will survive logout.
+
+## 4. Explain failures without switching paths
+
+- If a service command fails, report its human-readable error and the returned stderr log path. Do not return the page address as though startup succeeded.
+- If health readiness times out, say the process started but the page did not become usable, and point to `~/.goalboard/logs/web-service.error.log`.
+- If foreground startup reports the port is already in use, re-run managed service status and report the actual state; do not pick a random port and pretend it is the configured service.
+- On `unsupported`, do not use ordinary shell backgrounding. The only current fallback is an explicitly accepted foreground temporary run.
+- Never turn a startup failure into CLI/SQLite Goal manipulation. Goal lifecycle remains available only through host-provided `goalboard_v1_*` MCP tools.

--- a/specs/external-release-hardening/completion-audit.md
+++ b/specs/external-release-hardening/completion-audit.md
@@ -44,8 +44,9 @@ Work Item spec 为准。
    因此只有 HTTP、渲染结构和自动化证据，不能标记视觉通过。
 2. **README 真实截图更新。** 与当前五段正文和新版 demo 内容不一致的旧决定中心截图已经停止引用；
    必须在真实浏览器验收构建中重拍 Goal Tree、决定中心和设置页，不能用合成图代替。
-3. **增量进入 main。** onboarding 主改动已经由 PR #5 合入 `main`；新版 demo 和更新文档位于
-   PR #6，等待具有写权限的 reviewer 批准。
+3. **增量进入 main。** onboarding 主改动与新版 demo/更新文档已经由 PR #5、#6 合入 `main`；
+   Runtime 自然语言启动路由与服务健康就绪修复位于 PR #7，GitHub 判定可合并，仍在等待 main
+   规则要求的 reviewer 批准。
 4. **GoalBoard 验收记录回写。** 当前 Session 没有加载 `goalboard_v1_*` 工具。按 Runtime Skill
    不能用 CLI、SQLite 或 management MCP 代替；需要在工具已加载的新 Session 中连接用户选择的项目后写回。
 

--- a/specs/external-release-hardening/completion-audit.md
+++ b/specs/external-release-hardening/completion-audit.md
@@ -1,0 +1,63 @@
+# External release hardening completion audit
+
+更新于 2026-08-18。本文只记录当前代码、测试、安装结果和 GitHub 状态能够证明的事实；没有直接
+证据的条目保持未完成，不用“应该可以”代替验收。总目标和产品边界仍以同目录 `spec.md` 及各
+Work Item spec 为准。
+
+## 已有直接证据
+
+| 用户问题或要求 | 当前实现 | 直接证据 | 状态 |
+| --- | --- | --- | --- |
+| 安装不能偷偷修改项目、Runtime 配置或启动项目 | `goalboard install` 只维护 `~/.goalboard`；Runtime、服务、demo 都是独立预览/确认流程 | `tests/install.test.ts`；真实 `pnpm install:local` 输出 | 通过 |
+| 改源码后不能误装旧 `dist` | 本地唯一入口先 build；直接安装仓库会校验源码/构建指纹 | `tests/install.test.ts` 的 stale fingerprint 与 local install 用例 | 通过 |
+| 同版本内容变化不能继续跳过 | release 记录内容摘要；变化时原子刷新，失败回滚 | `tests/install.test.ts` 同版本刷新用例；本机多次返回“同版本内容已刷新” | 通过 |
+| 安装/接入后为什么要重启必须说清楚 | CLI、Web 接入预览、Skill 与 README 都说明 Runtime 只在 Session 启动时读取 MCP/Skill | `tests/runtime-integration.test.ts`、`tests/web.test.ts`、`README.md` | 通过 |
+| 前台 Web 随终端或 Codex 会话退出 | macOS 使用用户级 LaunchAgent，RunAtLoad/KeepAlive，日志可诊断；其他平台不假装常驻 | `tests/service.test.ts`；本机 `service status` 为 `running`，`/health` 为 200 | 通过 |
+| 更新后旧 Web 进程继续跑旧 release | 安装不静默杀进程，公开 `service restart --confirm` 等待卸载并验证新进程 | `tests/service.test.ts`、`tests/e2e.test.ts`；本机真实 restart 成功 | 通过 |
+| Codex stdio MCP 没有稳定 Session ID | 不把目录或 MCP 进程伪装成 Session；目录只给候选，用户确认后当前调用流继续 | `openai/codex#19937` 为 `CLOSED / NOT_PLANNED`；`tests/mcp.test.ts`、`tests/project-catalog.test.ts` | 通过 |
+| 新 Session 与项目关联不能靠猜 | 有 Session ID 时恢复该 Session；没有时同目录历史仍返回 `suggested` 并再次询问 | Runtime Skill、`tests/mcp.test.ts` fresh-session 用例 | 通过 |
+| 符号链接与一目录多项目 | workspace 使用 canonical realpath，可关联多个项目；普通选择不设默认，显式默认是单独决定 | `tests/project-catalog.test.ts` canonical workspace routing 用例 | 通过 |
+| 项目不等于 Git 仓库，项目身份不等于目录 | 用户选择的不可变 `project_id` 才是身份；每个项目有独立 DB，目录只作候选线索 | `src/projects/catalog.ts`；项目隔离与重复名称测试 | 通过 |
+| 旧静态 DB/兼容模式必须删除 | Runtime 不再读取静态项目 DB 环境配置，连接只走 project catalog；UI 不显示兼容模式 | `tests/mcp.test.ts`、`tests/runtime-integration.test.ts`、`tests/web.test.ts` 的负向断言 | 通过 |
+| Codex、Claude Code 和其他 Runtime 都能接入 | Codex/Claude adapter 负责配置事务；任意 MCP Runtime 可用工具调用 `_meta` Session ID 或显式稳定入口 | `tests/runtime-integration.test.ts`、`tests/mcp.test.ts` generic Runtime、`tests/e2e.test.ts` | 通过 |
+| Runtime 接入也可从 UI 完成 | 设置页提供探测、预览、确认、回滚和重启提示；不在页面打开时自动写配置 | `tests/web.test.ts` Runtime settings 用例；本机 `/api/settings/runtimes` 两项均 connected | 通过 |
+| Runtime 能从粗略想法开始，不要求用户先填 Web 表单 | Skill 走 Draft dialogue start/turn/resume，再提交完整 Goal Tree proposal | `tests/mcp.test.ts` Draft 对话与真实 E2E；Skill quick validation | 通过 |
+| Clarifier 是当前 Runtime 的工作指引，不是另一个 Session | `role` 只表示当前操作类型；当前对话持续提问并先持久化每次实质回答 | Runtime Skill 与 protocol；`tests/mcp.test.ts` | 通过 |
+| Goal 可以拆成多级 Goal family/tree | 一份 Proposal 可包含父、子、叶子及继续细分的子 Goal；用户决定后才物化 | `tests/v1.test.ts` Goal Tree proposal/decision/compound closure 用例 | 通过 |
+| 状态只有一套；澄清中的 Goal 不能显示进行中 | 从 canonical 事实派生唯一 work state；父 Goal 是“已澄清，等待子 Goal”，叶子是“待执行” | `tests/v1.test.ts` work states；`tests/web.test.ts` 状态映射 | 通过 |
+| Runtime 从 Available 自己选，不由 GoalBoard 派发唯一下一份 | `available → select_goal` 原子创建 Claim+Run；Skill 要求当前 Runtime 自主选择 | `tests/mcp.test.ts`、`tests/v1.test.ts` unified Available 用例 | 通过 |
+| 用户在对话里确认 Proposal 后能生效 | Runtime 只能转交当前对话的明确决定；GoalBoard 记录宿主元数据，不要求不存在的密码学证明 | `tests/mcp.test.ts` dialogue confirmation；`tests/v1.test.ts` Goal Tree decision | 通过 |
+| Goal 删除在 UI 与 MCP 共用同一接口且可恢复 | Web 与 Runtime MCP 都调用 `setGoalTrashed`；保留历史并安全停用/恢复关系 | `tests/v1.test.ts`、`tests/mcp.test.ts`、`tests/web.test.ts` trash/restore 用例 | 通过 |
+| 卸载不能误删用户项目 | 普通卸载只撤销 owned 程序/配置/服务并删除 regenerable demo；purge 另需精确 home+项目数 | `tests/uninstall.test.ts`；真实全新用户清场与复原已完成 | 通过 |
+| MCP 宿主枚举 resource templates 不能报错 | `resources/list` 与 `resources/templates/list` 都返回空列表 | `tests/mcp.test.ts`、`tests/e2e.test.ts` | 通过 |
+| 页面不能一次渲染全部 Goal，搜索时不能被自动同步抢占 | 初始只渲染当前 Goal；点击按需取 document；搜索输入期间延后/合并 cursor 同步 | `tests/web.test.ts`；安装后每页 1 个 Goal document、约 190–236KB | 通过 |
+| 顶栏不能和列表页重复搜索、新建、归档、回收站；设置页高度要一致 | 搜索、状态筛选、新建、待决定、归档和回收站统一在顶栏；桌面/移动顶栏高度统一 | `tests/web.test.ts` 导航唯一性与高度断言 | 自动化通过，待视觉复核 |
+| Goal 默认内容要先说业务问题、价值、结果和流程 | Skill/protocol 在 Draft 与 Proposal 前逐条检查 title/outcome/why/business_logic；技术细节留在约束/验收 | Skill 文本回归、quick validation、`plain-language-goal-presentation/spec.md` | 通过 |
+| 原有正文内容不能继续乱分块 | 当前 Goal 是五段连续文档，不新增第二套字段或总括“执行细节”折叠 | `tests/web.test.ts` 五段顺序与表单保留断言 | 自动化通过，待视觉复核 |
+| demo 与 README 要适合朋友第一次看 | demo 使用人话 Goal，覆盖完成/推进中/依赖阻塞/待澄清、Candidate、Risk 和回收站；README 有 3 分钟与更新路径 | `src/v1/demo.ts`；catalog/web/E2E 测试；本机 reset 后真实 API/HTML | 内容通过，截图待更新 |
+
+## 仍未完成的交付门槛
+
+1. **真实桌面与移动端视觉/交互 QA。** 需求书要求操作搜索、切换 Goal、设置、demo、回收站、
+   自动同步并检查移动布局。当前 Codex Session 没有暴露 Browser/Computer Use 所需的 UI 控制入口，
+   因此只有 HTTP、渲染结构和自动化证据，不能标记视觉通过。
+2. **README 真实截图更新。** 与当前五段正文和新版 demo 内容不一致的旧决定中心截图已经停止引用；
+   必须在真实浏览器验收构建中重拍 Goal Tree、决定中心和设置页，不能用合成图代替。
+3. **增量进入 main。** onboarding 主改动已经由 PR #5 合入 `main`；新版 demo 和更新文档位于
+   PR #6，等待具有写权限的 reviewer 批准。
+4. **GoalBoard 验收记录回写。** 当前 Session 没有加载 `goalboard_v1_*` 工具。按 Runtime Skill
+   不能用 CLI、SQLite 或 management MCP 代替；需要在工具已加载的新 Session 中连接用户选择的项目后写回。
+
+## 最近一次验证
+
+```text
+pnpm typecheck                                      PASS
+pnpm test                                           PASS (140/140)
+Skill quick_validate.py                             PASS
+pnpm pack --dry-run --json                          PASS
+packed release fresh-install E2E                    PASS
+本机 install:local + demo reset + service restart   PASS
+/health                                              200, project_count=2
+demo tree / decisions / trash                       200 / 200 / 200
+demo 导航                                            待决定 2 / 回收站 1
+```

--- a/specs/external-release-hardening/completion-audit.md
+++ b/specs/external-release-hardening/completion-audit.md
@@ -13,7 +13,8 @@ Work Item spec 为准。
 | 同版本内容变化不能继续跳过 | release 记录内容摘要；变化时原子刷新，失败回滚 | `tests/install.test.ts` 同版本刷新用例；本机多次返回“同版本内容已刷新” | 通过 |
 | 安装/接入后为什么要重启必须说清楚 | CLI、Web 接入预览、Skill 与 README 都说明 Runtime 只在 Session 启动时读取 MCP/Skill | `tests/runtime-integration.test.ts`、`tests/web.test.ts`、`README.md` | 通过 |
 | 前台 Web 随终端或 Codex 会话退出 | macOS 使用用户级 LaunchAgent，RunAtLoad/KeepAlive，日志可诊断；其他平台不假装常驻 | `tests/service.test.ts`；本机 `service status` 为 `running`，`/health` 为 200 | 通过 |
-| 更新后旧 Web 进程继续跑旧 release | 安装不静默杀进程，公开 `service restart --confirm` 等待卸载并验证新进程 | `tests/service.test.ts`、`tests/e2e.test.ts`；本机真实 restart 成功 | 通过 |
+| 用户对 Runtime 说“启动 GoalBoard”不能误开前台进程 | Skill 先查 managed service；首次常驻安装/旧配置修复先说明并确认，已停止则启动，已运行只返回地址；只有明确“临时打开”才走前台，非 macOS 不假装后台化 | `skills/goal-advance/references/service-start.md`；`tests/mcp.test.ts`、`tests/e2e.test.ts`；本机已安装 Codex Skill 与源码 SHA-256 一致 | 通过 |
+| 更新后旧 Web 进程继续跑旧 release，或进程已起但页面还打不开 | 安装不静默杀进程；公开 `service restart --confirm` 等待卸载、LaunchAgent running 和 `/health` 可访问后才返回 | `tests/service.test.ts` 延迟/失败健康检查、`tests/e2e.test.ts`；本机 restart 后立即 curl 成功 | 通过 |
 | Codex stdio MCP 没有稳定 Session ID | 不把目录或 MCP 进程伪装成 Session；目录只给候选，用户确认后当前调用流继续 | `openai/codex#19937` 为 `CLOSED / NOT_PLANNED`；`tests/mcp.test.ts`、`tests/project-catalog.test.ts` | 通过 |
 | 新 Session 与项目关联不能靠猜 | 有 Session ID 时恢复该 Session；没有时同目录历史仍返回 `suggested` 并再次询问 | Runtime Skill、`tests/mcp.test.ts` fresh-session 用例 | 通过 |
 | 符号链接与一目录多项目 | workspace 使用 canonical realpath，可关联多个项目；普通选择不设默认，显式默认是单独决定 | `tests/project-catalog.test.ts` canonical workspace routing 用例 | 通过 |
@@ -52,11 +53,13 @@ Work Item spec 为准。
 
 ```text
 pnpm typecheck                                      PASS
-pnpm test                                           PASS (140/140)
+pnpm test                                           PASS (142/142)
 Skill quick_validate.py                             PASS
 pnpm pack --dry-run --json                          PASS
 packed release fresh-install E2E                    PASS
 本机 install:local + demo reset + service restart   PASS
+/service restart 后立即访问 /health                 PASS
+已安装 Codex Skill 与源码内容摘要                   MATCH
 /health                                              200, project_count=2
 demo tree / decisions / trash                       200 / 200 / 200
 demo 导航                                            待决定 2 / 回收站 1

--- a/specs/external-release-hardening/spec.md
+++ b/specs/external-release-hardening/spec.md
@@ -93,6 +93,8 @@ GoalBoard Draft：`draft-44163d37-ebe8-411b-9220-ced1c0b05040`。
 4. `managed-web-service`：macOS LaunchAgent 的 preview/confirm/status/remove 与 UI/CLI。
 5. `safe-uninstall-and-demo-data`：数据分类、安全卸载、显式 demo 创建/重置/移除。
 6. `public-readme-and-e2e`：真实截图、README、发行包全新安装/重启/升级/卸载端到端验收。
+7. `runtime-service-launch-routing`：把“启动 GoalBoard”路由到受管理的常驻服务，把明确的“临时打开”
+   路由到前台 Web，并保证 Runtime 不会把服务管理误当作 Goal lifecycle fallback。
 
 依赖顺序：1 → 2；3 与 1 可独立；4 依赖 3 的稳定 launcher；5 依赖项目数据分类；6 最后
 消费全部真实行为。共享 catalog、MCP、README 和跨 Work Item 状态由主 Session 串行修改。
@@ -124,6 +126,8 @@ GoalBoard Draft：`draft-44163d37-ebe8-411b-9220-ced1c0b05040`。
 - 旧静态 DB 配置可在用户确认的新接入计划中迁走，生产代码与 UI 不再保留旧运行模式。
 - 真实 pack E2E 覆盖安装、Runtime 接入、重启续接、项目解析、对话确认、服务恢复、同版本
   刷新和安全卸载。
+- Runtime 收到“启动 GoalBoard”会先检查 managed service；macOS 首次常驻安装/旧配置修复先说明
+  影响并确认，只有明确“临时打开”才启动会随终端退出的前台 Web，非 macOS 不假装后台化。
 
 ## 验证
 

--- a/specs/external-release-hardening/work-items/managed-web-service/spec.md
+++ b/specs/external-release-hardening/work-items/managed-web-service/spec.md
@@ -8,6 +8,9 @@ Web 不再依赖某个终端或 Codex Session 活着；用户明确启用后，�
 当前实机证据：LaunchAgent 默认 `PATH` 不包含 NVM 的 Node，`#!/usr/bin/env node` 启动器会以
 127 退出；`launchctl print` 对崩溃重试中的任务仍返回成功，不能据此宣称 Web 正在运行；
 `bootout` 后立即 `bootstrap` 会短暂返回 37，需要只对这个“操作仍在进行”状态做有限重试。
+真实更新验收还发现：LaunchAgent 已进入 `running` 后，Web 端口可能仍有短暂时间没有开始监听；如果
+CLI 此时先打印“启动/重启成功”，用户立刻打开页面会看到一次连接失败。因此进程状态不是完成条件，
+公开成功结果还必须等待 loopback `/health` 返回可用。
 
 ## 范围
 
@@ -20,6 +23,10 @@ Web 不再依赖某个终端或 Codex Session 活着；用户明确启用后，�
 - owned receipt/hash 防止覆盖或删除用户修改的同名服务。
 - 状态检测区分“LaunchAgent 已加载”和“Web 进程正在运行”；owned 旧配置可预览修复，修复失败
   恢复原配置。
+- 进程运行但 `/health` 不可访问时状态为 `unhealthy`，不把页面错误显示成正常运行；Web 诊断页
+  提供受控重启入口。
+- install/start/restart 在确认 LaunchAgent 进程运行后继续有限等待 `http://127.0.0.1:4173/health`；
+  只有页面已可访问才返回成功，超时则给出日志位置明确报错，不能先打印成功。
 - 非 macOS 返回明确 unsupported；不使用 nohup 或后台 shell 伪装常驻。
 
 ## 验收
@@ -28,6 +35,7 @@ Web 不再依赖某个终端或 Codex Session 活着；用户明确启用后，�
 - 进程异常退出会恢复；用户登录/电脑重启后自动启动。
 - 重复安装幂等，冲突不覆盖，remove 只删除 owned 配置。
 - 崩溃重试中的 LaunchAgent 不显示为运行；服务配置升级后能加载新环境，失败时不丢失旧配置。
+- 延迟监听端口时 CLI 会等待；健康检查始终失败时 install/start/restart 返回失败，不宣称页面可用。
 - stop 与 remove 语义不同；日志和失败原因可从诊断页看到。
 
 ## 修改边界与验证

--- a/specs/external-release-hardening/work-items/public-readme-and-e2e/spec.md
+++ b/specs/external-release-hardening/work-items/public-readme-and-e2e/spec.md
@@ -32,6 +32,8 @@
 - README 没有旧静态 DB、兼容模式、nohup 或“当前 Session 会自动出现工具”的错误路径。
 - README 明确区分首次安装与已有安装更新；更新步骤包含先拉取源码、同内容安装入口、显式重启
   常驻 Web 和新开 Runtime Session，并说明不会自动重建 demo 或修改用户项目。
+- README 和已安装 Skill 都明确：对 Runtime 说“启动 GoalBoard”先检查并使用 managed service；
+  只有明确说“临时打开 GoalBoard”才使用会随终端退出的 `goalboard-web` 前台进程。
 - 所有截图来自验收构建，页面与 README 步骤一致。
 - 新用户路径不要求先手动构造 GoalBoard 数据。
 - 完整测试、pack dry-run、Skill 校验和关键浏览器流程通过。

--- a/specs/external-release-hardening/work-items/runtime-service-launch-routing/spec.md
+++ b/specs/external-release-hardening/work-items/runtime-service-launch-routing/spec.md
@@ -1,0 +1,86 @@
+# Runtime 自然语言启动 GoalBoard
+
+## 背景与目标
+
+GoalBoard 已提供 macOS 用户级 LaunchAgent 常驻服务，也保留 `goalboard-web` 前台调试入口；
+但 Runtime Skill 没有解释用户说“启动 GoalBoard”时应该走哪条路。Runtime 可能因此误用前台
+进程，并在终端或 Session 结束后让页面悄悄消失。
+
+本 Work Item 要让用户只用自然语言也能得到可预期的启动行为：普通“启动 GoalBoard”优先检查并
+使用受管理的常驻服务；“临时打开 GoalBoard”才运行前台 Web。
+
+## 当前行为与问题证据
+
+- `goalboard service status/install/start/restart` 已能探测、预览和确认 macOS LaunchAgent。
+- README 已分别描述常驻和前台命令，但 `skills/goal-advance/SKILL.md` 没有启动意图路由。
+- 真实更新验收还发现：LaunchAgent 进程进入 `running` 后端口可能尚未监听，CLI 曾经会提前报告
+  成功；这会让 Runtime 返回地址后用户第一次打开失败。
+
+## 范围与关键决策
+
+- 将“启动/打开 GoalBoard 页面”的服务管理意图，与 Goal lifecycle 明确分开。
+- Runtime 收到普通“启动 GoalBoard”后，先只读运行安装目录中的
+  `goalboard service status --home ~/.goalboard --json`，再按状态路由：
+  - macOS `absent`：用人话说明会安装用户级常驻后台服务、关闭终端后仍运行、登录后自启；只有
+    用户在当前对话明确确认，才执行 `service install --confirm`。
+  - `stopped`：用户的“启动”已经明确授权启动现有 owned 服务，执行 `service start --confirm`。
+  - `running`：不重复启停，只返回 `http://127.0.0.1:4173`。
+  - `unhealthy`：说明进程存在但页面不可访问，按用户已明确提出的启动意图受控执行
+    `service restart --confirm`，失败时返回日志位置。
+  - `needs_repair`：说明会更新 GoalBoard 自己的旧 LaunchAgent 配置并重启；取得明确确认后执行
+    `service install --confirm`。
+  - `unavailable` / `conflict`：解释缺少启动器或 ownership 冲突，不覆盖未知配置，不切换到另一份
+    数据或服务。
+  - 非 macOS `unsupported`：明确说明当前没有系统级常驻服务；只有用户进一步明确说“临时打开”
+    时才运行前台 Web。
+- 用户明确说“临时打开 GoalBoard”时，直接运行 `goalboard-web --home ~/.goalboard` 并说明它依附
+  当前终端/Session，关闭后会停止。不得用 `nohup`、后台 shell 或相似方式冒充常驻服务。
+- install/start/restart 只有在 `/health` 已可访问后才返回成功，Runtime 再返回页面地址。
+
+## 非目标
+
+- 不让 CLI、SQLite 或服务管理命令创建、选择、澄清、修改或完成 Goal。
+- 不把服务启动当作 `goalboard_v1` MCP 不可用时的 Goal lifecycle fallback。
+- 不在本轮实现 Linux systemd 或 Windows service。
+- 不自动覆盖未知或用户改写的 LaunchAgent。
+
+## 输入、输出与依赖
+
+- 输入：用户在当前 Runtime 中明确提出的“启动 GoalBoard”或“临时打开 GoalBoard”。
+- 状态输入：`goalboard service status --json` 返回的 managed service detection。
+- 输出：已健康可访问的本机地址、一次待确认的常驻安装/修复说明，或可行动的失败解释。
+- 依赖：稳定的 `~/.goalboard/bin/goalboard` 与 `goalboard-web` 启动器；macOS LaunchAgent provider。
+
+## 修改边界
+
+- `skills/goal-advance/SKILL.md` 与一个按需读取的服务启动 reference。
+- `skills/goal-advance/agents/openai.yaml`（若 Skill 面向用户的触发说明变更）。
+- `README.md`、外部发布验收记录。
+- Skill 内容测试、服务健康就绪测试与发行包 E2E 文档断言。
+
+## 验收标准
+
+- Skill 明确区分普通启动与临时打开，并规定先查 managed service 状态。
+- 首次安装常驻服务前，用户清楚知道持久化效果且必须明确确认。
+- 已停止、已运行、旧配置、冲突和非 macOS 均有唯一、可理解的路由。
+- 进程存在但页面不可访问时不会显示“运行中”，而是提供受控重启。
+- Runtime 不会把 `goalboard-web` 前台进程说成后台服务。
+- Runtime 不会把服务管理命令用于 Goal lifecycle 或绕过 MCP。
+- service install/start/restart 等到页面健康可用后才宣称成功。
+
+## 验证
+
+```bash
+node --import tsx --test tests/service.test.ts tests/mcp.test.ts tests/e2e.test.ts
+pnpm typecheck
+pnpm test
+python3 /Users/yijunwang/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/goal-advance
+pnpm pack --dry-run --json
+git diff --check
+```
+
+## 假设与开放问题
+
+- Runtime 可以执行用户明确请求的本地安装/服务命令；这项权限不延伸到 Goal 数据操作。
+- 页面当前固定监听 `127.0.0.1:4173`。未来支持自定义端口时，服务状态与健康检查需返回实际 URL，
+  Skill 不应自行猜端口。

--- a/src/install/web-service.ts
+++ b/src/install/web-service.ts
@@ -16,6 +16,7 @@ export type GoalBoardWebServiceState =
   | "absent"
   | "stopped"
   | "running"
+  | "unhealthy"
   | "needs_repair"
   | "conflict";
 
@@ -57,6 +58,8 @@ export interface GoalBoardWebServiceManagerOptions {
   platform?: NodeJS.Platform;
   uid?: number;
   runCommand?: (file: string, args: string[]) => Promise<{ code: number; stdout: string; stderr: string }>;
+  /** Returns true only after the managed Web endpoint can serve requests. */
+  healthCheck?: () => Promise<boolean>;
   /** Tests may remove the real launchd transition wait without changing retry behavior. */
   transitionDelayMilliseconds?: number;
 }
@@ -97,6 +100,7 @@ export class GoalBoardWebServiceManager {
   private readonly uid: number;
   private readonly nodeExecutablePath: string;
   private readonly runCommand: NonNullable<GoalBoardWebServiceManagerOptions["runCommand"]>;
+  private readonly healthCheck: NonNullable<GoalBoardWebServiceManagerOptions["healthCheck"]>;
   private readonly transitionDelayMilliseconds: number;
   private readonly plans = new Map<string, PreparedServicePlan>();
 
@@ -114,6 +118,7 @@ export class GoalBoardWebServiceManager {
     this.stdoutLog = path.join(this.homeDirectory, "logs", "web-service.log");
     this.stderrLog = path.join(this.homeDirectory, "logs", "web-service.error.log");
     this.runCommand = options.runCommand ?? runCommand;
+    this.healthCheck = options.healthCheck ?? goalBoardWebHealthCheck;
     this.transitionDelayMilliseconds = Math.max(0, options.transitionDelayMilliseconds ?? 250);
   }
 
@@ -154,11 +159,14 @@ export class GoalBoardWebServiceManager {
     if (plist !== this.plistSource()) {
       return this.detection("needs_repair", true, true, running, command, "GoalBoard Web 常驻服务使用旧配置，可预览并确认修复");
     }
-    return running
-      ? this.detection("running", true, true, true, command, "GoalBoard Web 常驻服务正在运行")
-      : this.detection("stopped", true, true, false, command, status.code === 0
+    if (!running) {
+      return this.detection("stopped", true, true, false, command, status.code === 0
         ? "GoalBoard Web 常驻服务已加载但进程未运行，请查看错误日志"
         : "GoalBoard Web 常驻服务已安装但当前未运行");
+    }
+    return await this.healthCheck()
+      ? this.detection("running", true, true, true, command, "GoalBoard Web 常驻服务正在运行，页面已可访问")
+      : this.detection("unhealthy", true, true, true, command, "GoalBoard Web 进程正在运行，但页面暂时不可访问；可受控重启并查看错误日志");
   }
 
   async prepare(action: GoalBoardWebServiceAction): Promise<GoalBoardWebServicePlan> {
@@ -289,6 +297,7 @@ ${args}
       if (kickstart.code !== 0) throw commandError("启动", kickstart);
     }
     await this.waitForRunning();
+    await this.waitForReady();
   }
 
   private async stop(): Promise<void> {
@@ -340,6 +349,20 @@ ${args}
     }
   }
 
+  private async waitForReady(): Promise<void> {
+    let ready = await this.healthCheck();
+    for (let attempt = 1; !ready && attempt < 25; attempt += 1) {
+      await delay(this.transitionDelayMilliseconds);
+      ready = await this.healthCheck();
+    }
+    if (!ready) {
+      throw new GoalBoardWebServiceError(
+        "service.command_failed",
+        `GoalBoard Web 进程已经启动，但页面健康检查仍未通过；请查看错误日志：${this.stderrLog}`,
+      );
+    }
+  }
+
   private async launchctl(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
     return this.runCommand("/bin/launchctl", args);
   }
@@ -387,7 +410,7 @@ function planStatus(action: GoalBoardWebServiceAction, detection: GoalBoardWebSe
   if (action === "install") return detection.state === "running" ? "no_change" : "ready";
   if (action === "start") {
     if (detection.state === "absent" || detection.state === "needs_repair") return "conflict";
-    return detection.running ? "no_change" : "ready";
+    return detection.state === "running" ? "no_change" : "ready";
   }
   if (action === "stop") return detection.running ? "ready" : "no_change";
   if (action === "restart") return detection.owned ? "ready" : "conflict";
@@ -403,7 +426,7 @@ function serviceChanges(
   if (status !== "ready") return [];
   if (action === "install") return [
     ...(detection.state === "absent" || detection.state === "needs_repair" ? [{ operation: "create" as const, target: plistPath }] : []),
-    { operation: "start", target: SERVICE_LABEL },
+    { operation: detection.state === "unhealthy" ? "restart" : "start", target: SERVICE_LABEL },
   ];
   return [{ operation: action, target: action === "remove" ? plistPath : SERVICE_LABEL }];
 }
@@ -433,6 +456,20 @@ async function runCommand(file: string, args: string[]): Promise<{ code: number;
   } catch (error) {
     const failure = error as Error & { code?: number | string; stdout?: string; stderr?: string };
     return { code: typeof failure.code === "number" ? failure.code : 1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? failure.message };
+  }
+}
+
+async function goalBoardWebHealthCheck(): Promise<boolean> {
+  try {
+    const response = await fetch("http://127.0.0.1:4173/health", {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(1_000),
+    });
+    if (!response.ok) return false;
+    const body = await response.json() as { status?: unknown };
+    return body.status === "ok";
+  } catch {
+    return false;
   }
 }
 

--- a/src/web/render.ts
+++ b/src/web/render.ts
@@ -5060,12 +5060,14 @@ function renderDiagnosticsSettings(view: GoalBoardSettingsView): string {
       ? { label: "尚未安装本体", tone: "warning" }
       : { label: "安装清单无效", tone: "danger" };
   const launchers = diagnostics.launchers.map((launcher) => `<li><span>${icon(launcher.state === "ready" ? "check" : "blocked")}<strong>${launcher.name}</strong><small>${escapeHtml(launcher.path)}</small></span><span class="settings-state settings-state--${launcher.state === "ready" ? "success" : "danger"}">${launcher.state === "ready" ? "可用" : "缺失"}</span></li>`).join("");
-  const serviceTone = service.state === "running" ? "success" : service.state === "stopped" || service.state === "absent" ? "warning" : "danger";
-  const serviceLabel = service.state === "running" ? "运行中" : service.state === "stopped" ? "已安装，未运行" : service.state === "absent" ? "未启用" : service.state === "unsupported" ? "当前系统不支持" : service.state === "conflict" ? "配置冲突" : "需要修复";
+  const serviceTone = service.state === "running" ? "success" : service.state === "stopped" || service.state === "absent" || service.state === "unhealthy" ? "warning" : "danger";
+  const serviceLabel = service.state === "running" ? "运行中" : service.state === "stopped" ? "已安装，未运行" : service.state === "unhealthy" ? "进程运行中，页面不可用" : service.state === "absent" ? "未启用" : service.state === "unsupported" ? "当前系统不支持" : service.state === "conflict" ? "配置冲突" : "需要修复";
   const serviceActions = service.state === "running"
     ? [["restart", "重启"], ["stop", "停止"], ["remove", "移除"]]
     : service.state === "stopped"
       ? [["start", "启动"], ["remove", "移除"]]
+      : service.state === "unhealthy"
+        ? [["restart", "重启并检查"], ["remove", "移除"]]
       : service.state === "absent" || service.state === "needs_repair"
         ? [["install", "启用常驻服务"]]
         : [];

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -214,6 +214,9 @@ test("packed release completes fresh install, Web setup, Runtime dialogue, resta
     assert.match(packedReadme, /goalboard_v1_context_resolve/);
     assert.match(packedReadme, /git pull --ff-only/);
     assert.match(packedReadme, /service restart/);
+    assert.match(packedReadme, /直接对 Runtime 说“启动 GoalBoard”/);
+    assert.match(packedReadme, /只有明确说“临时打开 GoalBoard”/);
+    assert.match(packedReadme, /非 macOS 目前没有系统级常驻服务/);
     assert.match(packedReadme, /demo reset --confirm/);
     assert.match(packedReadme, /用户项目、Runtime 配置和 demo 都不会被自动改写/);
     assert.match(packedReadme, /明确.*确认|显式/);
@@ -263,6 +266,12 @@ test("packed release completes fresh install, Web setup, Runtime dialogue, resta
       });
       assert.equal(runtimeConfirm.status, 200, await runtimeConfirm.text());
       assert.match(await readFile(join(userHome, ".codex", "config.toml"), "utf8"), /GOALBOARD_RUNTIME_ID = "codex"/);
+      const installedServiceStart = await readFile(
+        join(userHome, ".codex", "skills", "goal-advance", "references", "service-start.md"),
+        "utf8",
+      );
+      assert.match(installedServiceStart, /service status/);
+      assert.match(installedServiceStart, /临时打开 GoalBoard/);
 
       const claudePlanResponse = await securePost(origin, token, "/api/settings/runtimes/claude-code/plan", { action: "connect" });
       assert.equal(claudePlanResponse.status, 200);

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -189,8 +189,15 @@ describe("mcp server", () => {
       path.join(ROOT, "skills/goal-advance/references/protocol.md"),
       "utf8",
     );
+    const serviceStart = fs.readFileSync(
+      path.join(ROOT, "skills/goal-advance/references/service-start.md"),
+      "utf8",
+    );
     assert.match(skill, /one public GoalBoard entry for the Runtime currently talking with the user/);
-    assert.match(skill, /Use only the host-provided `goalboard_v1_\*` Runtime MCP tools/);
+    assert.match(skill, /For every Goal lifecycle operation, use only the host-provided `goalboard_v1_\*` Runtime MCP tools/);
+    assert.match(skill, /“启动 GoalBoard” or “打开 GoalBoard”/);
+    assert.match(skill, /Only use the foreground `goalboard-web` launcher when the user explicitly says “临时打开 GoalBoard”/);
+    assert.match(skill, /Starting Web does not select a project or authorize any Goal change/);
     assert.match(skill, /does not open another Runtime, dispatch a separate Session/);
     assert.match(skill, /edit the user's project files/);
     assert.match(skill, /Never infer a project from Git, a directory, a repository name/);
@@ -251,8 +258,17 @@ describe("mcp server", () => {
     assert.match(protocol, /user_confirmed=true/);
     assert.match(protocol, /pending_relation_ids/);
     assert.match(protocol, /do not create another Board, change configuration, swap databases, or use a CLI fallback/);
+    assert.match(serviceStart, /service status --home "\$HOME\/\.goalboard" --json/);
+    assert.match(serviceStart, /关闭终端后页面仍会运行，登录后会自动启动/);
+    assert.match(serviceStart, /`stopped`.*`service start --confirm`/s);
+    assert.match(serviceStart, /`unhealthy`.*`service restart --confirm`/s);
+    assert.match(serviceStart, /`needs_repair`.*explicit confirmation/s);
+    assert.match(serviceStart, /`unsupported`.*no GoalBoard system-level persistent-service integration/s);
+    assert.match(serviceStart, /Do not add `nohup`, `&`, `disown`/);
+    assert.match(serviceStart, /Goal lifecycle remains available only through host-provided `goalboard_v1_\*` MCP tools/);
     assert.doesNotMatch(skill, /GOALBOARD_DATABASE/);
     assert.doesNotMatch(protocol, /GOALBOARD_DATABASE/);
+    assert.doesNotMatch(serviceStart, /GOALBOARD_DATABASE/);
   });
 
   it("Runtime Skill defines natural, resumable, and structured forward conversations", () => {

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -19,6 +19,8 @@ async function fixture() {
   let printOutput = "state = running\npid = 4242\n";
   let bootstrapInProgressCount = 0;
   let bootoutTransitionPrintCount = 0;
+  let healthCheckFailuresRemaining = 0;
+  let healthCheckCount = 0;
   const commands: string[][] = [];
   const manager = new GoalBoardWebServiceManager({
     homeDirectory: home,
@@ -26,6 +28,14 @@ async function fixture() {
     platform: "darwin",
     uid: 501,
     transitionDelayMilliseconds: 0,
+    async healthCheck() {
+      healthCheckCount += 1;
+      if (healthCheckFailuresRemaining > 0) {
+        healthCheckFailuresRemaining -= 1;
+        return false;
+      }
+      return true;
+    },
     async runCommand(file, args) {
       commands.push([file, ...args]);
       if (args[0] === "print") {
@@ -67,6 +77,8 @@ async function fixture() {
     setPrintOutput: (value: string) => { printOutput = value; },
     setBootstrapInProgressCount: (value: number) => { bootstrapInProgressCount = value; },
     setBootoutTransitionPrintCount: (value: number) => { bootoutTransitionPrintCount = value; },
+    setHealthCheckFailures: (value: number) => { healthCheckFailuresRemaining = value; },
+    healthCheckCount: () => healthCheckCount,
   };
 }
 
@@ -113,6 +125,58 @@ test("a loaded LaunchAgent whose process crashed is not reported as running", as
     const started = await item.manager.confirm({ plan_id: start.plan_id, decision: "confirmed" });
     assert.equal(started.detection.state, "running");
     assert.equal(item.commands.filter((command) => command[1] === "kickstart").length, 1);
+  } finally {
+    await rm(item.directory, { recursive: true, force: true });
+  }
+});
+
+test("start waits for the Web health endpoint and never reports a process-only success", async () => {
+  const delayed = await fixture();
+  try {
+    delayed.setHealthCheckFailures(3);
+    const install = await delayed.manager.prepare("install");
+    const installed = await delayed.manager.confirm({ plan_id: install.plan_id, decision: "confirmed" });
+    assert.equal(installed.status, "installed");
+    assert.equal(installed.detection.state, "running");
+    assert.equal(delayed.healthCheckCount(), 5);
+  } finally {
+    await rm(delayed.directory, { recursive: true, force: true });
+  }
+
+  const unavailable = await fixture();
+  try {
+    unavailable.setHealthCheckFailures(30);
+    const install = await unavailable.manager.prepare("install");
+    await assert.rejects(
+      () => unavailable.manager.confirm({ plan_id: install.plan_id, decision: "confirmed" }),
+      (error: unknown) => error instanceof GoalBoardWebServiceError
+        && error.code === "service.command_failed"
+        && /健康检查仍未通过/.test(error.message),
+    );
+    assert.equal(unavailable.healthCheckCount(), 25);
+    await assert.rejects(stat(unavailable.manager.plistPath));
+    await assert.rejects(stat(unavailable.manager.receiptPath));
+  } finally {
+    await rm(unavailable.directory, { recursive: true, force: true });
+  }
+});
+
+test("service status reports a running process with an unavailable page as unhealthy and start repairs it", async () => {
+  const item = await fixture();
+  try {
+    const install = await item.manager.prepare("install");
+    await item.manager.confirm({ plan_id: install.plan_id, decision: "confirmed" });
+
+    item.setHealthCheckFailures(1);
+    const start = await item.manager.prepare("start");
+    assert.equal(start.detection.state, "unhealthy");
+    assert.equal(start.status, "ready");
+    assert.match(start.detection.message, /页面暂时不可访问/);
+
+    const started = await item.manager.confirm({ plan_id: start.plan_id, decision: "confirmed" });
+    assert.equal(started.status, "started");
+    assert.equal(started.detection.state, "running");
+    assert.ok(item.commands.some((command) => command[1] === "kickstart"));
   } finally {
     await rm(item.directory, { recursive: true, force: true });
   }

--- a/tests/uninstall.test.ts
+++ b/tests/uninstall.test.ts
@@ -166,6 +166,7 @@ test("changed owned files block uninstall and a failed service step leaves a rec
       userHomeDirectory: failed.userHome,
       platform: "darwin",
       uid: 501,
+      async healthCheck() { return true; },
       async runCommand(_file, args) {
         if (args[0] === "print") return { code: loaded ? 0 : 113, stdout: loaded ? "state = running\npid = 4242\n" : "", stderr: loaded ? "" : "not found" };
         if (args[0] === "bootstrap") { loaded = true; return { code: 0, stdout: "", stderr: "" }; }

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -794,11 +794,13 @@ test("Web diagnostics previews and confirms the same managed Web service lifecyc
   mkdirSync(userHome, { recursive: true });
   writeFileSync(join(fixture.homeDirectory, "bin", "goalboard-web"), "#!/bin/sh\nexit 0\n");
   let loaded = false;
+  let healthy = true;
   const service = new GoalBoardWebServiceManager({
     homeDirectory: fixture.homeDirectory,
     userHomeDirectory: userHome,
     platform: "darwin",
     uid: 501,
+    async healthCheck() { return healthy; },
     async runCommand(_file, args) {
       if (args[0] === "print") return { code: loaded ? 0 : 113, stdout: loaded ? "state = running\npid = 4242\n" : "", stderr: loaded ? "" : "not found" };
       if (args[0] === "bootstrap") loaded = true;
@@ -842,6 +844,13 @@ test("Web diagnostics previews and confirms the same managed Web service lifecyc
 
     const status = (await (await webFetch(`${origin}/api/settings/web-service`)).json()) as { state: string };
     assert.equal(status.state, "running");
+
+    healthy = false;
+    const unhealthyStatus = (await (await webFetch(`${origin}/api/settings/web-service`)).json()) as { state: string };
+    assert.equal(unhealthyStatus.state, "unhealthy");
+    const unhealthyPage = await (await webFetch(`${origin}/settings/diagnostics`)).text();
+    assert.match(unhealthyPage, /进程运行中，页面不可用/);
+    assert.match(unhealthyPage, /data-web-service-action="restart"/);
   } finally {
     await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
   }


### PR DESCRIPTION
## Summary
- route natural-language “启动 GoalBoard” through managed-service status and macOS LaunchAgent confirmation
- reserve `goalboard-web` foreground mode for explicit “临时打开” requests and explain non-macOS limits
- wait for `/health`, expose unhealthy service state, and add controlled restart UI
- document and audit the installed-user flow

## Verification
- `pnpm typecheck`
- `pnpm test` (142/142)
- Skill `quick_validate.py`
- `pnpm pack --dry-run --json`
- real `pnpm install:local` + managed restart + immediate `/health`
- installed Codex Skill hashes match repository sources