### PR TITLE
docs: describe the three-pane workbench and extra Runtime adapters

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -9,7 +9,7 @@ Have you been here before: the plan you worked out with AI yesterday is gone whe
 So we built **GoalBoard** — a **non-intrusive** goal ledger shared between humans and AI, with **rich MCP integration** and **no AI of its own**:
 
 - **Non-intrusive**: it doesn't launch your AI or force tasks onto anyone; work that can be done sits in a list and the AI picks it up itself;
-- **Rich MCP**: connect to Codex, Claude Code, or any MCP runtime; switch conversations or switch AIs and the goal is still there;
+- **Rich MCP**: Settings can auto-adapt Codex, Claude Code, OpenCode, Pi Agent, and Grok Build; any other MCP runtime can still use the same protocol. Switch conversations or switch AIs and the goal is still there;
 - **No AI of its own**: it isn't tied to any model — your AI stays the main actor;
 - **A goal ledger**: goals, breakdowns, progress, and completion criteria are all on the books — who's working, where things stand, what's blocked, what's missing, and what's waiting for your decision are visible at a glance, so you never have to guess from chat history.
 
@@ -34,6 +34,8 @@ Let a first-time user complete one round of goal collaboration
 
 The demo also includes pending decisions, a Risk for forgetting to open a new session after first-time integration, and an old proposal that can be restored from the trash. Goal documents read top-down: "what the goal is → what counts as done → how to move it forward → risks and rules → history." Older screenshots that no longer match the current structure or demo are not shown.
 
+The browser and the optional macOS App open the same local page (`http://127.0.0.1:4173`). A Goal page is a three-pane workbench: Goal Tree on the left, a continuous document in the middle, and a local terminal on the right. Use Add terminal to open Claude Code, Codex, OpenCode, Pi Agent, Grok Build, or a custom command **on the current Goal**. Tabs belong to that Goal; switching Goals swaps the document and that Goal's tab group, while the previous terminals keep running in the background. Opening the page does not bind a Session or claim work. Only opening a terminal binds this work entry, and only Advance this Goal types into the TUI. The Decision Center, archive, and trash stay two-pane. The UI defaults to Chinese and can switch to English; Goal titles and body text stay in their original language.
+
 ## 3-minute experience
 
 You need Node.js 20+, pnpm, and macOS (the persistent Web service currently uses LaunchAgent; other platforms can still run Web in the foreground).
@@ -56,9 +58,9 @@ pnpm install:local
 
 Open `http://127.0.0.1:4173`:
 
-1. Enter the demo project and look at the Goal Tree, pending decisions, and completion evidence.
-2. In "Settings → Runtime", pick Codex or Claude Code, review the change preview, and confirm the integration.
-3. **Open a new Runtime Session** and say "continue with GoalBoard." Runtimes read MCP and Skill manifests only at Session startup, so tools installed just now won't appear in the current conversation.
+1. Enter the demo project and look at the Goal Tree, pending decisions, and completion evidence; open a Goal and you can Add terminal on the right.
+2. In "Settings → Runtime", pick Codex, Claude Code, OpenCode, Pi Agent, or Grok Build, review the change preview, and confirm the integration.
+3. **Open a new Session of that Runtime** and say "continue with GoalBoard." Runtimes read MCP and Skill manifests only at Session startup, so tools installed just now won't appear in the current conversation.
 
 Once integrated, you can also tell the Runtime to "start GoalBoard." It first checks the managed service state: on macOS, the first enablement explains that this is a user-level background service that starts at login and keeps running after the terminal closes, and only installs after your explicit confirmation; if it is already running, it just returns the page address. Only when you explicitly say "open GoalBoard temporarily" will it use a foreground process tied to the current terminal or Session. Non-macOS platforms currently have no system-level persistent service; the Runtime says so plainly and asks whether to open it temporarily.
 
@@ -126,7 +128,7 @@ pnpm install:local
 "$HOME/.goalboard/bin/goalboard-web" --home "$HOME/.goalboard"
 ```
 
-After opening `http://127.0.0.1:4173`, you can create, import, rename, and open projects in Settings, and configure Codex / Claude Code integration first. Selecting a project only changes what the page browses; it does not bind or switch the current Runtime Session. Existing legacy DBs are migrated into a project only after you explicitly select and confirm.
+After opening `http://127.0.0.1:4173`, you can create, import, rename, and open projects in Settings, and configure Runtime integration first. Selecting a project only changes what the page browses; it does not bind or switch the current Runtime Session. Existing legacy DBs are migrated into a project only after you explicitly select and confirm. On macOS you can also run `pnpm desktop`; the App is only a window around the same page.
 
 Running `goalboard-web` directly is still foreground mode, good for temporary debugging; closing the terminal closes the page too. On macOS you can instead use the user-level LaunchAgent persistent service — preview first, then confirm:
 
@@ -173,9 +175,9 @@ If a Runtime config, Skill link, LaunchAgent, or launcher was rewritten by the u
 
 `goalboard install` only installs the GoalBoard program and prints the install location, CLI/MCP/Web launchers, and safety boundaries; automation can use `goalboard install --json`. The install never creates projects, associates Sessions, starts services, or modifies Runtime configuration.
 
-Runtime integration is handled by the same domain service. The current adapter read-only probes Codex, Claude Code, OpenCode, Pi Agent, and Grok Build, then generates a preview containing config paths, the GoalBoard MCP entry, the Skill link, backup location, and restart instructions; it writes only after the user explicitly confirms the current Runtime and plan. MCP and Skill are validated as one transaction; on failure, the original config bytes and Skill state are restored. Removal only undoes what the GoalBoard ownership receipt still records as untouched by the user. Unknown same-name configs or Skills show a conflict and are never overwritten.
+Runtime integration is handled by the same domain service. The current adapter read-only probes Codex, Claude Code, OpenCode, Pi Agent, and Grok Build, then writes to each host's official location: Codex / Grok Build use `[mcp_servers.goalboard]` in `~/.codex/config.toml` or `~/.grok/config.toml`, Claude Code uses `mcpServers.goalboard` in `~/.claude.json`, OpenCode uses `mcp.goalboard` in `~/.config/opencode/opencode.json`, and Pi Agent uses `~/.pi/agent/mcp.json` for `pi-mcp-adapter` (Pi itself has no MCP). It also links the `goal-advance` Skill into the matching skills directory. The preview lists config paths, the MCP entry, the Skill link, the backup location, and restart instructions; it writes only after the user explicitly confirms the current Runtime and plan. MCP and Skill are validated as one transaction; on failure, the original config bytes and Skill state are restored. Removal only undoes what the GoalBoard ownership receipt still records as untouched by the user. Unknown same-name configs or Skills show a conflict and are never overwritten.
 
-After the integration is confirmed, **you must open a new Codex / Claude Code Session** for it to take effect: Runtimes read MCP and Skill manifests only at Session startup, and the current conversation doesn't dynamically gain just-written tools. In the new Session you can copy "continue with GoalBoard" to resume; GoalBoard shows projects previously used in the current directory and asks you to confirm. If you want a project to be entered automatically in the future, you must additionally set it as the directory default. The integration preview lists every change and this resume note item by item.
+After the integration is confirmed, **you must open a new Session of that Runtime** for it to take effect: Runtimes read MCP and Skill manifests only at Session startup, and the current conversation doesn't dynamically gain just-written tools. In the new Session you can copy "continue with GoalBoard" to resume; GoalBoard shows projects previously used in the current directory and asks you to confirm. If you want a project to be entered automatically in the future, you must additionally set it as the directory default. If Pi does not show GoalBoard tools, run `pi install npm:pi-mcp-adapter` once and open a new session. The integration preview lists every change and this resume note item by item.
 
 Creating a project and associating the current Session are separate operations: after the user invokes the unified Skill in the current Runtime, the Skill uses `context-list-projects`, `context-bind`, or `context-create-and-bind`, and writes into GoalBoard's own data directory only after the user explicitly chooses. Web can create, import, rename, and open projects, and manage already-confirmed Session and workspace associations; selecting a project in the page never changes the Runtime connection, and a new Session still asks by default unless the user explicitly set a directory default project.
 
@@ -255,7 +257,7 @@ GoalBoard connects projects through the unified Skill: the Runtime may provide a
 
 The Runtime host only provides a Session ID when it can guarantee stability; it is not a Git URL, directory name, repository structure, or a string inferred from conversation. GoalBoard supports any MCP Runtime providing a Session ID in `_meta.threadId`, `_meta.sessionId`, or `_meta["goalboard/sessionId"]` on each `tools/call`, and also supports stable environment signals from adapters like Claude Code; ordinary tool arguments are never treated as host identity. When the same long-lived MCP process receives a different Session ID, it clears the previous Session's connection. Without a Session ID, GoalBoard can still use the canonical workspace to find historical candidates, but never pretends a directory or MCP process is a Session. One workspace can associate multiple `project_id`s; a normal selection does not set a default automatically.
 
-The install itself never writes Runtime configuration. Codex and Claude Code should use the stable launcher after the user confirms the integration preview; other Runtime hosts can explicitly provide the same set of environment values:
+The install itself never writes Runtime configuration. Those five Runtimes should use the stable launcher after the user confirms the integration preview; other Runtime hosts can explicitly provide the same set of environment values:
 
 ```bash
 GOALBOARD_HOME="$HOME/.goalboard" \
@@ -327,15 +329,19 @@ Complex payloads can be passed with `--json` or `--file payload.json`. The CLI i
 ```text
 src/v1/                      SQLite Store, Coordinator, types, CLI, and one-time import
 src/mcp/server.ts            V1-only MCP Server
-src/web/                     Goal Tree and document-style Goal workspace
+src/web/                     Goal Tree, document workspace, local PTY, and i18n
+src/desktop/                 Third-pane launch recipes and advance prompt
 src/install/                 Install, Runtime integration, persistent service, and safe uninstall
 src/cli/main.ts              Product CLI and V1 management entry
+desktop/                     Optional macOS App shell around the same Web
 examples/seed-demo.mts       Dev script calling the product demo lifecycle
 docs/screenshots/            README product screenshots
 skills/goal-advance/         Runtime working protocol
 tests/v1.test.ts             Coordinator, CLI, migration, and protocol regression
 tests/mcp.test.ts            MCP audience, permission, and connection regression
 tests/web.test.ts            Web data and interaction regression
+tests/desktop-tui.test.ts    Third-pane launch, panels, and local PTY regression
+tests/i18n.test.ts           UI locale regression
 tests/uninstall.test.ts      User-data retention, strong confirmation, and receipt regression
 PRODUCT.md                   Product definition
 DESIGN.md                    Shipped UI design system

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 所以我们推出 **GoalBoard**——一个**不侵入**的、提供**丰富 MCP** 的、**不包含自身 AI 功能**的，人和 AI 之间的**目标对账本**：
 
 - **不侵入**：不启动你的 AI，也不把任务硬塞给谁；能做的事摆在列表里，AI 自己挑着做；
-- **丰富 MCP**：接入 Codex、Claude Code 等任何 MCP Runtime；换对话、换 AI，目标都在；
+- **丰富 MCP**：设置页可自动适配 Codex、Claude Code、OpenCode、Pi Agent、Grok Build；其他 MCP Runtime 也能连上同一套协议。换对话、换 AI，目标都在；
 - **没有自己的 AI**：不捆绑任何模型，你的 AI 才是主角；
 - **目标对账本**：目标、拆分、进度、完成标准都记在账上——谁在干、做到哪、卡在哪、还差什么、什么在等你决定，打开就清楚，不用靠聊天记录去猜。
 
@@ -34,6 +34,8 @@
 
 示例还包含待决定事项、首次接入后忘记新开会话的 Risk，以及一条可在回收站恢复的旧方案。Goal 正文按“目标是什么 → 怎样才算完成 → 现在怎么推进 → 风险与规则 → 历史”阅读。与当前结构或示例内容不一致的旧正文截图不再展示。
 
+浏览器和可选的 macOS App 打开同一套本机页面（`http://127.0.0.1:4173`）。Goal 详情是三栏工作台：左边 Goal Tree，中间连续文档，右边本机终端。点「添加终端」可在**当前这条 Goal** 上打开 Claude Code、Codex、OpenCode、Pi Agent、Grok Build 或自定义命令；标签跟着 Goal 走，切到另一条 Goal 会换文档和那一组标签，原来的终端继续在后台跑。打开页面不会绑定 Session，也不会替你领取工作；只有点开终端才绑定这个工作入口，只有点「推进这个 Goal」才往输入框打字。决定中心、归档和回收站保持两栏。界面默认中文，可切换英文；Goal 标题和正文保持原文。
+
 ## 3 分钟体验
 
 需要 Node.js 20+、pnpm，以及 macOS（常驻 Web 服务目前使用 LaunchAgent；其他系统仍可前台启动 Web）。
@@ -55,9 +57,9 @@ pnpm install:local
 
 打开 `http://127.0.0.1:4173`：
 
-1. 进入示例项目，查看 Goal Tree、待决定事项和完成证据。
-2. 在“设置 → Runtime”中选择 Codex 或 Claude Code，先看改动预览，再确认接入。
-3. **新开一个 Runtime Session**，说“继续用 GoalBoard”。Runtime 只在 Session 启动时读取 MCP 和 Skill，所以当前对话不会凭空出现刚安装的工具。
+1. 进入示例项目，查看 Goal Tree、待决定事项和完成证据；打开一条 Goal 后，右侧可以「添加终端」。
+2. 在“设置 → Runtime”中选择 Codex、Claude Code、OpenCode、Pi Agent 或 Grok Build，先看改动预览，再确认接入。
+3. **新开一个该 Runtime 的 Session**，说“继续用 GoalBoard”。Runtime 只在 Session 启动时读取 MCP 和 Skill，所以当前对话不会凭空出现刚安装的工具。
 
 接入生效后也可以直接对 Runtime 说“启动 GoalBoard”。它会先检查受管理的服务状态：macOS
 首次启用时会说明这是登录后自启、关闭终端后仍运行的用户级后台服务，并在你明确确认后安装；
@@ -132,7 +134,7 @@ pnpm install:local
 "$HOME/.goalboard/bin/goalboard-web" --home "$HOME/.goalboard"
 ```
 
-打开 `http://127.0.0.1:4173` 后，可以在设置中创建、导入、改名和打开项目，也可以先配置 Codex / Claude Code 接入。选择一个项目只改变网页浏览位置，不会自动绑定或切换当前 Runtime Session；已有旧 DB 只有明确选择并确认后才会迁入项目。
+打开 `http://127.0.0.1:4173` 后，可以在设置中创建、导入、改名和打开项目，也可以先配置 Runtime 接入。选择一个项目只改变网页浏览位置，不会自动绑定或切换当前 Runtime Session；已有旧 DB 只有明确选择并确认后才会迁入项目。macOS 上也可从仓库运行 `pnpm desktop`，App 只是同一套页面的窗口壳。
 
 直接运行 `goalboard-web` 仍是前台模式，适合临时调试；关闭终端会同时关闭页面。macOS 上可改用用户级 LaunchAgent 常驻服务，先预览再确认：
 >
@@ -179,9 +181,9 @@ pnpm install:local
 
 `goalboard install` 只完成 GoalBoard 本体安装，默认输出安装位置、CLI/MCP/Web 启动器和安全边界；自动化可以使用 `goalboard install --json`。安装不会顺带创建项目、关联 Session、启动服务或修改 Runtime 配置。
 
-安装后的 Runtime 接入由同一领域服务完成。当前 adapter 会只读探测 Codex、Claude Code、OpenCode、Pi Agent 和 Grok Build，并先生成包含配置路径、GoalBoard MCP entry、Skill 链接、备份位置和重启说明的预览；只有用户对当前 Runtime 和当前 plan 明确确认后才会写入。MCP 与 Skill 作为一个事务验证，失败会恢复原配置字节和原 Skill 状态。移除时只撤销 GoalBoard ownership receipt 记录且仍未被用户改写的内容。未知同名配置或 Skill 会显示冲突，不会被覆盖。
+安装后的 Runtime 接入由同一领域服务完成。当前 adapter 会只读探测 Codex、Claude Code、OpenCode、Pi Agent 和 Grok Build，并按各家官方位置写入：Codex / Grok Build 用 `~/.codex/config.toml` 或 `~/.grok/config.toml` 的 `[mcp_servers.goalboard]`，Claude Code 用 `~/.claude.json` 的 `mcpServers.goalboard`，OpenCode 用 `~/.config/opencode/opencode.json` 的 `mcp.goalboard`，Pi Agent 用 `~/.pi/agent/mcp.json`（供 `pi-mcp-adapter` 读取；Pi 本体没有 MCP）。同时把 `goal-advance` Skill 链到对应 skills 目录。预览包含配置路径、MCP 入口、Skill 链接、备份位置和重启说明；只有用户对当前 Runtime 和当前 plan 明确确认后才会写入。MCP 与 Skill 作为一个事务验证，失败会恢复原配置字节和原 Skill 状态。移除时只撤销 GoalBoard ownership receipt 记录且仍未被用户改写的内容。未知同名配置或 Skill 会显示冲突，不会被覆盖。
 
-接入确认完成后，**必须新开 Codex / Claude Code Session**才会生效：Runtime 只在 Session 启动时读取 MCP 与 Skill 清单，当前对话不会动态出现刚写入的工具。新 Session 可直接复制「继续用 GoalBoard」续接；GoalBoard 会展示当前目录以前使用过的项目并请你确认。若希望以后自动进入某个项目，需要另外明确把它设为目录默认。接入预览界面会逐条展示改动内容和这段续接说明。
+接入确认完成后，**必须新开那个 Runtime 的 Session**才会生效：Runtime 只在 Session 启动时读取 MCP 与 Skill 清单，当前对话不会动态出现刚写入的工具。新 Session 可直接复制「继续用 GoalBoard」续接；GoalBoard 会展示当前目录以前使用过的项目并请你确认。若希望以后自动进入某个项目，需要另外明确把它设为目录默认。Pi 若看不到 GoalBoard 工具，先运行一次 `pi install npm:pi-mcp-adapter` 再开新会话。接入预览界面会逐条展示改动内容和这段续接说明。
 
 项目创建和当前 Session 关联是独立操作：用户在当前 Runtime 调用统一 Skill 后，Skill 使用 `context-list-projects`、`context-bind` 或 `context-create-and-bind`，并且只在用户明确选择后写入 GoalBoard 自己的数据目录。Web 可创建、导入、改名和打开项目，也可管理已经确认过的 Session 与 workspace 关联；网页中的项目选择本身不会改变 Runtime 连接，新 Session 默认仍要先询问，除非用户明确设置了目录默认项目。
 
@@ -261,7 +263,7 @@ GoalBoard 通过统一 Skill 连接项目：Runtime 可以提供 Session ID，�
 
 Runtime 宿主只在自己能保证稳定性的情况下提供 Session ID；它不是 Git 地址、目录名、仓库结构或模型从对话中推断的字符串。GoalBoard 支持任意 MCP Runtime 在每次 `tools/call` 的 `_meta.threadId`、`_meta.sessionId` 或 `_meta["goalboard/sessionId"]` 中提供 Session ID，也支持 Claude Code 等 adapter 的稳定环境信号；普通工具参数不会被当成宿主身份。同一个长驻 MCP 进程收到不同 Session ID 时会清掉前一个 Session 的连接。没有 Session ID 时，GoalBoard 仍可把 canonical workspace 用于查找历史候选，但绝不把目录或 MCP 进程伪装成 Session。一个 workspace 可关联多个 `project_id`；普通选择不自动设默认。
 
-安装本身不会写入 Runtime 配置。Codex 和 Claude Code 应由用户在接入预览中确认后使用稳定 launcher；其他 Runtime host 可以显式提供同一组环境值：
+安装本身不会写入 Runtime 配置。上述五个 Runtime 应由用户在接入预览中确认后使用稳定 launcher；其他 Runtime host 可以显式提供同一组环境值：
 
 ```bash
 GOALBOARD_HOME="$HOME/.goalboard" \
@@ -333,15 +335,19 @@ candidate-decide | rewire-confirm | import-v3
 ```text
 src/v1/                      SQLite Store、Coordinator、types、CLI 与一次性导入
 src/mcp/server.ts            V1-only MCP Server
-src/web/                     Goal Tree 与文档式 Goal 工作区
+src/web/                     Goal Tree、文档式工作区、本机 PTY 与 i18n
+src/desktop/                 第三栏启动配方与推进提示
 src/install/                 安装、Runtime 接入、常驻服务与安全卸载
 src/cli/main.ts              产品 CLI 与 V1 管理入口
+desktop/                     可选 macOS App 壳，复用同一套 Web
 examples/seed-demo.mts       调用产品 demo 生命周期的开发脚本
 docs/screenshots/            README 产品截图
 skills/goal-advance/         Runtime 工作协议
 tests/v1.test.ts             Coordinator、CLI、迁移与协议回归
 tests/mcp.test.ts            MCP audience、权限与连接回归
 tests/web.test.ts            Web 数据与交互回归
+tests/desktop-tui.test.ts    第三栏启动、面板与本机 PTY 回归
+tests/i18n.test.ts           界面语言回归
 tests/uninstall.test.ts      用户数据保留、强确认与恢复收据回归
 PRODUCT.md                   产品定义
 DESIGN.md                    shipped UI 设计系统

--- a/tests/runtime-integration.test.ts
+++ b/tests/runtime-integration.test.ts
@@ -378,6 +378,65 @@ test("removal refuses to delete GoalBoard entries or Skill links changed after c
   });
 });
 
+test("OpenCode, Pi Agent, and Grok Build write official MCP and Skill locations", async () => {
+  await withFixture(async (fixture) => {
+    const integration = service(fixture);
+    const opencodeConfig = join(fixture.userHome, ".config", "opencode", "opencode.json");
+    const piConfig = join(fixture.userHome, ".pi", "agent", "mcp.json");
+    const grokConfig = join(fixture.userHome, ".grok", "config.toml");
+    await mkdir(join(fixture.userHome, ".config", "opencode"), { recursive: true });
+    await mkdir(join(fixture.userHome, ".pi", "agent"), { recursive: true });
+    await mkdir(join(fixture.userHome, ".grok"), { recursive: true });
+    await writeFile(opencodeConfig, `${JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      model: "keep-opencode",
+      mcp: { other: { type: "local", command: ["keep-me"] } },
+    }, null, 2)}\n`);
+    await writeFile(piConfig, `${JSON.stringify({
+      settings: { toolPrefix: "mcp" },
+      mcpServers: { other: { command: "keep-pi" } },
+    }, null, 2)}\n`);
+    await writeFile(grokConfig, 'model = "keep-grok"\n\n[mcp_servers.other]\ncommand = "keep-grok"\n');
+
+    for (const runtimeId of ["opencode", "pi-agent", "grok-build"] as const) {
+      const plan = await integration.prepare(runtimeId, "connect");
+      assert.equal(plan.status, "ready", runtimeId);
+      const result = await integration.confirm({ runtime_id: runtimeId, plan_id: plan.plan_id, decision: "confirmed" });
+      assert.equal(result.status, "connected", runtimeId);
+      assert.equal((await integration.detect(runtimeId)).connection_state, "connected", runtimeId);
+    }
+
+    const opencode = JSON.parse(await readFile(opencodeConfig, "utf8")) as {
+      model: string;
+      mcp: Record<string, { type?: string; command?: string[]; environment?: Record<string, string> }>;
+    };
+    assert.equal(opencode.model, "keep-opencode");
+    assert.deepEqual(opencode.mcp.other.command, ["keep-me"]);
+    assert.equal(opencode.mcp.goalboard.type, "local");
+    assert.deepEqual(opencode.mcp.goalboard.command, [fixture.launcher]);
+    assert.equal(opencode.mcp.goalboard.environment?.GOALBOARD_RUNTIME_ID, "opencode");
+    assert.equal(await readlink(join(fixture.userHome, ".config", "opencode", "skills", "goal-advance")), fixture.skillSource);
+
+    const pi = JSON.parse(await readFile(piConfig, "utf8")) as {
+      settings: { toolPrefix: string };
+      mcpServers: Record<string, { command?: string; env?: Record<string, string>; lifecycle?: string }>;
+    };
+    assert.equal(pi.settings.toolPrefix, "mcp");
+    assert.equal(pi.mcpServers.other.command, "keep-pi");
+    assert.equal(pi.mcpServers.goalboard.command, fixture.launcher);
+    assert.equal(pi.mcpServers.goalboard.env?.GOALBOARD_RUNTIME_ID, "pi-agent");
+    assert.equal(pi.mcpServers.goalboard.lifecycle, "eager");
+    assert.equal(await readlink(join(fixture.userHome, ".pi", "agent", "skills", "goal-advance")), fixture.skillSource);
+
+    const grok = await readFile(grokConfig, "utf8");
+    assert.match(grok, /model = "keep-grok"/);
+    assert.match(grok, /\[mcp_servers\.other\][\s\S]*command = "keep-grok"/);
+    assert.match(grok, /\[mcp_servers\.goalboard\]/);
+    assert.match(grok, /GOALBOARD_RUNTIME_ID = "grok-build"/);
+    assert.equal(await readlink(join(fixture.userHome, ".grok", "skills", "goal-advance")), fixture.skillSource);
+  });
+});
+
 test("Runtime host keeps Session identity independent from the canonical workspace", () => {
   const codex = runtimeContextHostFromEnvironment({
     GOALBOARD_RUNTIME_ID: "codex",

--- a/tests/uninstall.test.ts
+++ b/tests/uninstall.test.ts
@@ -25,7 +25,7 @@ async function fixture() {
   const runtimeIntegrationService = new RuntimeIntegrationService({
     homeDirectory: home,
     userHomeDirectory: userHome,
-    runtimeExecutables: { codex: null, "claude-code": null },
+    runtimeExecutables: { codex: null, "claude-code": null, opencode: null, "pi-agent": null, "grok-build": null },
   });
   const webServiceManager = new GoalBoardWebServiceManager({
     homeDirectory: home,
@@ -185,7 +185,7 @@ test("changed owned files block uninstall and a failed service step leaves a rec
     const runtimeIntegrationService = new RuntimeIntegrationService({
       homeDirectory: failed.home,
       userHomeDirectory: failed.userHome,
-      runtimeExecutables: { codex: null, "claude-code": null },
+      runtimeExecutables: { codex: null, "claude-code": null, opencode: null, "pi-agent": null, "grok-build": null },
     });
     const service = new GoalBoardUninstallService({
       homeDirectory: failed.home,

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -136,9 +136,11 @@ function webRuntimeIntegrationFixture(homeDirectory: string) {
   writeFileSync(launcher, "#!/bin/sh\nexit 0\n");
   const codex = join(runtimeBin, "codex");
   const claude = join(runtimeBin, "claude");
-  writeFileSync(codex, "#!/bin/sh\nexit 0\n");
-  writeFileSync(claude, "#!/bin/sh\nexit 0\n");
-  [launcher, codex, claude].forEach((file) => chmodSync(file, 0o755));
+  const opencode = join(runtimeBin, "opencode");
+  const pi = join(runtimeBin, "pi");
+  const grok = join(runtimeBin, "grok");
+  for (const file of [codex, claude, opencode, pi, grok]) writeFileSync(file, "#!/bin/sh\nexit 0\n");
+  [launcher, codex, claude, opencode, pi, grok].forEach((file) => chmodSync(file, 0o755));
   return {
     userHomeDirectory,
     skill,
@@ -146,7 +148,7 @@ function webRuntimeIntegrationFixture(homeDirectory: string) {
     service: new RuntimeIntegrationService({
       homeDirectory,
       userHomeDirectory,
-      runtimeExecutables: { codex, "claude-code": claude },
+      runtimeExecutables: { codex, "claude-code": claude, opencode, "pi-agent": pi, "grok-build": grok },
       validateConnection: () => true,
     }),
   };
@@ -695,6 +697,9 @@ test("Web settings use shared Runtime and project services for confirmed setup f
     assert.match(runtimePage, /Runtime 接入/);
     assert.match(runtimePage, /Codex/);
     assert.match(runtimePage, /Claude Code/);
+    assert.match(runtimePage, /OpenCode/);
+    assert.match(runtimePage, /Pi Agent/);
+    assert.match(runtimePage, /Grok Build/);
     assert.match(runtimePage, /未接入/);
     assert.match(runtimePage, /data-runtime-plan="codex"/);
     assert.match(runtimePage, /data-runtime-plan-dialog/);


### PR DESCRIPTION
## Summary
- 更新中英文 README：三栏工作台、本机终端、浏览器与 macOS App 共用同一页面。
- 写明 OpenCode / Pi Agent / Grok Build 的官方接入路径，以及 Pi 需要 `pi-mcp-adapter`。
- 补上这三个 Runtime adapter 的写入测试，并让设置页/卸载测试覆盖它们。

## Test plan
- [ ] 阅读 README.md / README.en.md 的界面速览、3 分钟体验、安装后下一步，确认和当前产品一致
- [ ] `node --import tsx --test tests/runtime-integration.test.ts`
- [ ] `node --import tsx --test --test-name-pattern "Web settings" tests/web.test.ts`


Made with [Cursor](https://cursor.com)