### PR TITLE
chore: share Runtime IDs and local-web checks

### DIFF
--- a/src/desktop/launch.ts
+++ b/src/desktop/launch.ts
@@ -1,21 +1,13 @@
-export const DESKTOP_RUNTIME_KINDS = [
-  "codex",
-  "claude-code",
-  "opencode",
-  "pi-agent",
-  "grok-build",
-  "generic",
-] as const;
-export type DesktopRuntimeKind = (typeof DESKTOP_RUNTIME_KINDS)[number];
-type NamedDesktopRuntimeKind = Exclude<DesktopRuntimeKind, "generic">;
+import {
+  isDesktopRuntimeKind,
+  isSupportedRuntimeId,
+  RUNTIME_DISPLAY_NAMES,
+  runtimeDisplayName,
+  type DesktopRuntimeKind,
+  type SupportedRuntimeId,
+} from "../runtimes.js";
 
-export function isDesktopRuntimeKind(value: string): value is DesktopRuntimeKind {
-  return (DESKTOP_RUNTIME_KINDS as readonly string[]).includes(value);
-}
-
-function isNamedDesktopRuntimeKind(value: string): value is NamedDesktopRuntimeKind {
-  return value !== "generic" && isDesktopRuntimeKind(value);
-}
+export { isDesktopRuntimeKind, runtimeDisplayName as desktopRuntimeTitle, type DesktopRuntimeKind };
 
 export interface DesktopLaunchSpec {
   runtime_kind: DesktopRuntimeKind;
@@ -26,42 +18,31 @@ export interface DesktopLaunchSpec {
 
 interface DesktopRuntimeRecipe {
   command: string;
-  title: string;
   resumeArgs: (sessionId: string) => string[];
 }
 
-const DESKTOP_RUNTIME_RECIPES: Record<NamedDesktopRuntimeKind, DesktopRuntimeRecipe> = {
+const DESKTOP_RUNTIME_RECIPES: Record<SupportedRuntimeId, DesktopRuntimeRecipe> = {
   codex: {
     command: "codex",
-    title: "Codex",
     resumeArgs: (sessionId) => ["resume", sessionId],
   },
   "claude-code": {
     command: "claude",
-    title: "Claude Code",
     resumeArgs: (sessionId) => ["--resume", sessionId],
   },
   opencode: {
     command: "opencode",
-    title: "OpenCode",
     resumeArgs: (sessionId) => ["--session", sessionId],
   },
   "pi-agent": {
     command: "pi",
-    title: "Pi Agent",
     resumeArgs: (sessionId) => ["--session", sessionId],
   },
   "grok-build": {
     command: "grok",
-    title: "Grok Build",
     resumeArgs: (sessionId) => ["--resume", sessionId],
   },
 };
-
-export function desktopRuntimeTitle(runtimeKind: string): string {
-  if (runtimeKind === "generic") return "自定义命令";
-  return isNamedDesktopRuntimeKind(runtimeKind) ? DESKTOP_RUNTIME_RECIPES[runtimeKind].title : runtimeKind;
-}
 
 export function desktopLaunchSpec(input: {
   runtime_kind: string;
@@ -70,13 +51,14 @@ export function desktopLaunchSpec(input: {
   resume_session_id?: string | null;
 }): DesktopLaunchSpec {
   const resume = input.resume_session_id?.trim() || null;
-  if (isNamedDesktopRuntimeKind(input.runtime_kind)) {
+  if (isSupportedRuntimeId(input.runtime_kind)) {
     const recipe = DESKTOP_RUNTIME_RECIPES[input.runtime_kind];
+    const title = RUNTIME_DISPLAY_NAMES[input.runtime_kind];
     return {
       runtime_kind: input.runtime_kind,
       command: input.command?.trim() || recipe.command,
       args: resume ? recipe.resumeArgs(resume) : [...(input.args ?? [])],
-      title: resume ? `${recipe.title} · ${resume.slice(0, 8)}` : recipe.title,
+      title: resume ? `${title} · ${resume.slice(0, 8)}` : title,
     };
   }
   const command = input.command?.trim();
@@ -109,5 +91,31 @@ export function desktopPanelEnv(input: {
     GOALBOARD_WEB_URL: "http://127.0.0.1:4173",
     TERM: "xterm-256color",
     COLORTERM: "truecolor",
+  };
+}
+
+export function desktopPanelSpawnPayload(input: {
+  homeDirectory: string;
+  panel: {
+    panel_id: string;
+    runtime_kind: string;
+    launch_command: string;
+    launch_args: string[];
+    cwd: string | null;
+    work_context_id: string;
+    goal_id: string;
+  };
+}): { command: string; args: string[]; cwd: string | null; env: Record<string, string> } {
+  return {
+    command: input.panel.launch_command,
+    args: input.panel.launch_args,
+    cwd: input.panel.cwd,
+    env: desktopPanelEnv({
+      homeDirectory: input.homeDirectory,
+      runtimeId: input.panel.runtime_kind,
+      panelId: input.panel.panel_id,
+      workContextId: input.panel.work_context_id,
+      goalId: input.panel.goal_id,
+    }),
   };
 }

--- a/src/install/runtime-integration.ts
+++ b/src/install/runtime-integration.ts
@@ -4,16 +4,17 @@ import { constants as fsConstants } from "node:fs";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import {
+  RUNTIME_DISPLAY_NAMES,
+  SUPPORTED_RUNTIME_IDS,
+  isSupportedRuntimeId,
+  type SupportedRuntimeId,
+} from "../runtimes.js";
+
+export { SUPPORTED_RUNTIME_IDS, isSupportedRuntimeId, type SupportedRuntimeId };
 
 const INTEGRATION_OWNER = "goalboard-runtime-integration-v1";
 const INSTALLER_OWNER = "goalboard-home-install-v1";
-
-export const SUPPORTED_RUNTIME_IDS = ["codex", "claude-code", "opencode", "pi-agent", "grok-build"] as const;
-export type SupportedRuntimeId = (typeof SUPPORTED_RUNTIME_IDS)[number];
-
-export function isSupportedRuntimeId(value: string): value is SupportedRuntimeId {
-  return (SUPPORTED_RUNTIME_IDS as readonly string[]).includes(value);
-}
 export type RuntimeIntegrationAction = "connect" | "remove";
 export type RuntimeConnectionState =
   | "not_detected"
@@ -191,45 +192,48 @@ export class RuntimeIntegrationError extends Error {
   }
 }
 
+function desiredConnectionFor(runtimeId: SupportedRuntimeId): RuntimeAdapter["desiredConnection"] {
+  return (artifacts, goalboardHome) => ({
+    runtimeId,
+    launcherPath: artifacts.launcherPath,
+    goalboardHome,
+  });
+}
+
 const CODEX_ADAPTER: RuntimeAdapter = {
   id: "codex",
-  displayName: "Codex",
+  displayName: RUNTIME_DISPLAY_NAMES.codex,
   executableNames: ["codex"],
   detectionPaths: (userHome) => [path.join(userHome, ".codex")],
   configPath: (userHome) => path.join(userHome, ".codex", "config.toml"),
   skillPath: (userHome) => path.join(userHome, ".codex", "skills", "goal-advance"),
-  desiredConnection: (artifacts, goalboardHome) => ({
-    runtimeId: "codex",
-    launcherPath: artifacts.launcherPath,
-    goalboardHome,
-  }),
+  desiredConnection: desiredConnectionFor("codex"),
   inspectConfig: inspectCodexConfig,
   connectConfig: connectCodexConfig,
   removeConfig: removeCodexConfig,
-  restartInstructions: restartInstructionsFor("Codex"),
+  restartInstructions: restartInstructionsFor(RUNTIME_DISPLAY_NAMES.codex),
 };
 
 const CLAUDE_CODE_ADAPTER: RuntimeAdapter = {
   id: "claude-code",
-  displayName: "Claude Code",
+  displayName: RUNTIME_DISPLAY_NAMES["claude-code"],
   executableNames: ["claude"],
   detectionPaths: (userHome) => [path.join(userHome, ".claude"), path.join(userHome, ".claude.json")],
   configPath: (userHome) => path.join(userHome, ".claude.json"),
   skillPath: (userHome) => path.join(userHome, ".claude", "skills", "goal-advance"),
-  desiredConnection: (artifacts, goalboardHome) => ({
-    runtimeId: "claude-code",
-    launcherPath: artifacts.launcherPath,
-    goalboardHome,
+  desiredConnection: desiredConnectionFor("claude-code"),
+  ...jsonMcpHandlers({
+    parse: parseJsonObject,
+    label: "Claude Code 用户配置",
+    rootKey: "mcpServers",
+    desiredEntry: desiredClaudeEntry,
   }),
-  inspectConfig: inspectClaudeConfig,
-  connectConfig: connectClaudeConfig,
-  removeConfig: removeClaudeConfig,
-  restartInstructions: restartInstructionsFor("Claude Code"),
+  restartInstructions: restartInstructionsFor(RUNTIME_DISPLAY_NAMES["claude-code"]),
 };
 
 const OPENCODE_ADAPTER: RuntimeAdapter = {
   id: "opencode",
-  displayName: "OpenCode",
+  displayName: RUNTIME_DISPLAY_NAMES.opencode,
   executableNames: ["opencode"],
   detectionPaths: (userHome) => [
     path.join(userHome, ".config", "opencode"),
@@ -237,54 +241,49 @@ const OPENCODE_ADAPTER: RuntimeAdapter = {
   ],
   configPath: (userHome) => path.join(userHome, ".config", "opencode", "opencode.json"),
   skillPath: (userHome) => path.join(userHome, ".config", "opencode", "skills", "goal-advance"),
-  desiredConnection: (artifacts, goalboardHome) => ({
-    runtimeId: "opencode",
-    launcherPath: artifacts.launcherPath,
-    goalboardHome,
+  desiredConnection: desiredConnectionFor("opencode"),
+  ...jsonMcpHandlers({
+    parse: parseJsoncObject,
+    label: "OpenCode 用户配置",
+    rootKey: "mcp",
+    emptyRoot: { $schema: "https://opencode.ai/config.json" },
+    desiredEntry: desiredOpenCodeEntry,
   }),
-  inspectConfig: inspectOpenCodeConfig,
-  connectConfig: connectOpenCodeConfig,
-  removeConfig: removeOpenCodeConfig,
-  restartInstructions: restartInstructionsFor("OpenCode"),
+  restartInstructions: restartInstructionsFor(RUNTIME_DISPLAY_NAMES.opencode),
 };
 
 const PI_AGENT_ADAPTER: RuntimeAdapter = {
   id: "pi-agent",
-  displayName: "Pi Agent",
+  displayName: RUNTIME_DISPLAY_NAMES["pi-agent"],
   executableNames: ["pi"],
   detectionPaths: (userHome) => [path.join(userHome, ".pi"), path.join(userHome, ".pi", "agent")],
   configPath: (userHome) => path.join(userHome, ".pi", "agent", "mcp.json"),
   skillPath: (userHome) => path.join(userHome, ".pi", "agent", "skills", "goal-advance"),
-  desiredConnection: (artifacts, goalboardHome) => ({
-    runtimeId: "pi-agent",
-    launcherPath: artifacts.launcherPath,
-    goalboardHome,
+  desiredConnection: desiredConnectionFor("pi-agent"),
+  ...jsonMcpHandlers({
+    parse: parseJsonObject,
+    label: "Pi Agent MCP 配置",
+    rootKey: "mcpServers",
+    desiredEntry: desiredPiEntry,
   }),
-  inspectConfig: inspectPiConfig,
-  connectConfig: connectPiConfig,
-  removeConfig: removePiConfig,
   restartInstructions: [
-    ...restartInstructionsFor("Pi Agent"),
+    ...restartInstructionsFor(RUNTIME_DISPLAY_NAMES["pi-agent"]),
     "Pi 本体不内置 MCP。GoalBoard 会写入 ~/.pi/agent/mcp.json，供 pi-mcp-adapter 读取。若新 Session 里看不到 GoalBoard 工具，先运行 `pi install npm:pi-mcp-adapter` 再开新会话。Skill 不依赖 adapter，可用 /skill:goal-advance。",
   ],
 };
 
 const GROK_BUILD_ADAPTER: RuntimeAdapter = {
   id: "grok-build",
-  displayName: "Grok Build",
+  displayName: RUNTIME_DISPLAY_NAMES["grok-build"],
   executableNames: ["grok"],
   detectionPaths: (userHome) => [path.join(userHome, ".grok")],
   configPath: (userHome) => path.join(userHome, ".grok", "config.toml"),
   skillPath: (userHome) => path.join(userHome, ".grok", "skills", "goal-advance"),
-  desiredConnection: (artifacts, goalboardHome) => ({
-    runtimeId: "grok-build",
-    launcherPath: artifacts.launcherPath,
-    goalboardHome,
-  }),
+  desiredConnection: desiredConnectionFor("grok-build"),
   inspectConfig: inspectCodexConfig,
   connectConfig: connectCodexConfig,
   removeConfig: removeCodexConfig,
-  restartInstructions: restartInstructionsFor("Grok Build"),
+  restartInstructions: restartInstructionsFor(RUNTIME_DISPLAY_NAMES["grok-build"]),
 };
 
 const ADAPTERS: readonly RuntimeAdapter[] = [
@@ -539,7 +538,7 @@ export class RuntimeIntegrationService {
       });
     }
 
-    const publicPlan = this.publicPlan(common, alreadyConnected && receipt ? "no_change" : "ready", changes, backupPath,
+    const publicPlan = runtimePublicPlan(common, alreadyConnected && receipt ? "no_change" : "ready", changes, backupPath,
       alreadyConnected && receipt ? `${adapter.displayName} 已经接入，无需重复写入。` : `准备接入 ${adapter.displayName}。`);
     return {
       publicPlan,
@@ -607,7 +606,7 @@ export class RuntimeIntegrationService {
       },
     ];
     return {
-      publicPlan: this.publicPlan(common, "ready", changes, backupPath, `准备移除 ${adapter.displayName} 的 GoalBoard 接入。`),
+      publicPlan: runtimePublicPlan(common, "ready", changes, backupPath, `准备移除 ${adapter.displayName} 的 GoalBoard 接入。`),
       adapter,
       beforeConfigText: snapshot.configText,
       beforeConfigHash: snapshot.configHash,
@@ -641,31 +640,6 @@ export class RuntimeIntegrationService {
       planHash,
       adapter: snapshot.adapter,
       action,
-    };
-  }
-
-  private publicPlan(
-    common: { planId: string; planHash: string; adapter: RuntimeAdapter; action: RuntimeIntegrationAction },
-    status: RuntimeIntegrationPlan["status"],
-    changes: RuntimeIntegrationChange[],
-    backupPath: string | null,
-    message: string,
-  ): RuntimeIntegrationPlan {
-    const verb = common.action === "connect" ? "接入" : "移除接入";
-    return {
-      schema_version: 1,
-      plan_id: common.planId,
-      plan_hash: common.planHash,
-      runtime_id: common.adapter.id,
-      display_name: common.adapter.displayName,
-      action: common.action,
-      status,
-      changes,
-      backup_path: backupPath,
-      confirmation: `确认${verb} ${common.adapter.displayName}`,
-      alternative: "可以保持当前状态，稍后再从设置页操作；GoalBoard 本体和已有项目不会受影响。",
-      restart_instructions: [...common.adapter.restartInstructions],
-      message,
     };
   }
 
@@ -844,6 +818,31 @@ function detectionMessage(state: RuntimeConnectionState, displayName: string): s
   return `${displayName} 存在同名配置冲突`;
 }
 
+function runtimePublicPlan(
+  common: { planId: string; planHash: string; adapter: RuntimeAdapter; action: RuntimeIntegrationAction },
+  status: RuntimeIntegrationPlan["status"],
+  changes: RuntimeIntegrationChange[],
+  backupPath: string | null,
+  message: string,
+): RuntimeIntegrationPlan {
+  const verb = common.action === "connect" ? "接入" : "移除接入";
+  return {
+    schema_version: 1,
+    plan_id: common.planId,
+    plan_hash: common.planHash,
+    runtime_id: common.adapter.id,
+    display_name: common.adapter.displayName,
+    action: common.action,
+    status,
+    changes,
+    backup_path: backupPath,
+    confirmation: `确认${verb} ${common.adapter.displayName}`,
+    alternative: "可以保持当前状态，稍后再从设置页操作；GoalBoard 本体和已有项目不会受影响。",
+    restart_instructions: [...common.adapter.restartInstructions],
+    message,
+  };
+}
+
 function preparedWithStatus(
   common: { planId: string; planHash: string; adapter: RuntimeAdapter; action: RuntimeIntegrationAction },
   snapshot: RuntimeSnapshot,
@@ -851,23 +850,8 @@ function preparedWithStatus(
   status: RuntimeIntegrationPlan["status"],
   message: string,
 ): PreparedPlan {
-  const verb = common.action === "connect" ? "接入" : "移除接入";
   return {
-    publicPlan: {
-      schema_version: 1,
-      plan_id: common.planId,
-      plan_hash: common.planHash,
-      runtime_id: common.adapter.id,
-      display_name: common.adapter.displayName,
-      action: common.action,
-      status,
-      changes: [],
-      backup_path: null,
-      confirmation: `确认${verb} ${common.adapter.displayName}`,
-      alternative: "可以保持当前状态，稍后再从设置页操作；GoalBoard 本体和已有项目不会受影响。",
-      restart_instructions: [...common.adapter.restartInstructions],
-      message,
-    },
+    publicPlan: runtimePublicPlan(common, status, [], null, message),
     adapter: common.adapter,
     beforeConfigText: snapshot.configText,
     beforeConfigHash: snapshot.configHash,
@@ -952,15 +936,24 @@ async function restoreSkillSnapshot(targetPath: string, snapshot: SkillSnapshot)
   }
 }
 
+function goalboardProcessEnv(desired: DesiredConnection): Record<string, string> {
+  return {
+    GOALBOARD_HOME: desired.goalboardHome,
+    GOALBOARD_MCP_AUDIENCE: "runtime",
+    GOALBOARD_RUNTIME_ID: desired.runtimeId,
+  };
+}
+
 function desiredCodexFamily(desired: DesiredConnection): string {
+  const env = goalboardProcessEnv(desired);
   return [
     "[mcp_servers.goalboard]",
     `command = ${tomlString(desired.launcherPath)}`,
     "",
     "[mcp_servers.goalboard.env]",
-    `GOALBOARD_HOME = ${tomlString(desired.goalboardHome)}`,
-    `GOALBOARD_MCP_AUDIENCE = ${tomlString("runtime")}`,
-    `GOALBOARD_RUNTIME_ID = ${tomlString(desired.runtimeId)}`,
+    `GOALBOARD_HOME = ${tomlString(env.GOALBOARD_HOME)}`,
+    `GOALBOARD_MCP_AUDIENCE = ${tomlString(env.GOALBOARD_MCP_AUDIENCE)}`,
+    `GOALBOARD_RUNTIME_ID = ${tomlString(env.GOALBOARD_RUNTIME_ID)}`,
   ].join("\n");
 }
 
@@ -1020,42 +1013,8 @@ function desiredClaudeEntry(desired: DesiredConnection): Record<string, unknown>
     type: "stdio",
     command: desired.launcherPath,
     args: [],
-    env: {
-      GOALBOARD_HOME: desired.goalboardHome,
-      GOALBOARD_MCP_AUDIENCE: "runtime",
-      GOALBOARD_RUNTIME_ID: desired.runtimeId,
-    },
+    env: goalboardProcessEnv(desired),
   };
-}
-
-function inspectClaudeConfig(contents: string | null, desired: DesiredConnection): ConfigInspection {
-  if (contents == null) return { state: "absent", summary: "未配置 GoalBoard MCP", entryFingerprint: null };
-  const root = parseJsonObject(contents, "Claude Code 用户配置");
-  const servers = objectOrEmpty(root.mcpServers);
-  const entry = servers.goalboard;
-  if (entry == null) return { state: "absent", summary: "未配置 GoalBoard MCP", entryFingerprint: null };
-  const expected = desiredClaudeEntry(desired);
-  if (canonicalJson(entry) === canonicalJson(expected)) {
-    return { state: "current", summary: "当前 GoalBoard MCP 配置", entryFingerprint: digest(canonicalJson(expected)) };
-  }
-  if (/goalboard|GOALBOARD_/i.test(canonicalJson(entry))) {
-    return { state: "legacy", summary: "旧版 GoalBoard MCP 配置", entryFingerprint: digest(canonicalJson(entry)) };
-  }
-  return { state: "conflict", summary: "同名 MCP entry 不属于 GoalBoard", entryFingerprint: digest(canonicalJson(entry)) };
-}
-
-function connectClaudeConfig(contents: string | null, desired: DesiredConnection): string {
-  const root = contents == null ? {} : parseJsonObject(contents, "Claude Code 用户配置");
-  const servers = { ...objectOrEmpty(root.mcpServers), goalboard: desiredClaudeEntry(desired) };
-  return replaceTopLevelJsonProperty(contents, root, "mcpServers", servers);
-}
-
-function removeClaudeConfig(contents: string | null): string | null {
-  if (contents == null) return null;
-  const root = parseJsonObject(contents, "Claude Code 用户配置");
-  const servers = { ...objectOrEmpty(root.mcpServers) };
-  delete servers.goalboard;
-  return replaceTopLevelJsonProperty(contents, root, "mcpServers", servers);
 }
 
 function desiredOpenCodeEntry(desired: DesiredConnection): Record<string, unknown> {
@@ -1063,86 +1022,54 @@ function desiredOpenCodeEntry(desired: DesiredConnection): Record<string, unknow
     type: "local",
     command: [desired.launcherPath],
     enabled: true,
-    environment: {
-      GOALBOARD_HOME: desired.goalboardHome,
-      GOALBOARD_MCP_AUDIENCE: "runtime",
-      GOALBOARD_RUNTIME_ID: desired.runtimeId,
-    },
+    environment: goalboardProcessEnv(desired),
   };
-}
-
-function inspectOpenCodeConfig(contents: string | null, desired: DesiredConnection): ConfigInspection {
-  if (contents == null) return { state: "absent", summary: "未配置 GoalBoard MCP", entryFingerprint: null };
-  const root = parseJsoncObject(contents, "OpenCode 用户配置");
-  const entry = objectOrEmpty(root.mcp).goalboard;
-  if (entry == null) return { state: "absent", summary: "未配置 GoalBoard MCP", entryFingerprint: null };
-  const expected = desiredOpenCodeEntry(desired);
-  if (canonicalJson(entry) === canonicalJson(expected)) {
-    return { state: "current", summary: "当前 GoalBoard MCP 配置", entryFingerprint: digest(canonicalJson(expected)) };
-  }
-  if (/goalboard|GOALBOARD_/i.test(canonicalJson(entry))) {
-    return { state: "legacy", summary: "旧版 GoalBoard MCP 配置", entryFingerprint: digest(canonicalJson(entry)) };
-  }
-  return { state: "conflict", summary: "同名 MCP entry 不属于 GoalBoard", entryFingerprint: digest(canonicalJson(entry)) };
-}
-
-function connectOpenCodeConfig(contents: string | null, desired: DesiredConnection): string {
-  const root = contents == null
-    ? { $schema: "https://opencode.ai/config.json" }
-    : parseJsoncObject(contents, "OpenCode 用户配置");
-  const mcp = { ...objectOrEmpty(root.mcp), goalboard: desiredOpenCodeEntry(desired) };
-  return replaceTopLevelJsonProperty(contents, root, "mcp", mcp);
-}
-
-function removeOpenCodeConfig(contents: string | null): string | null {
-  if (contents == null) return null;
-  const root = parseJsoncObject(contents, "OpenCode 用户配置");
-  const mcp = { ...objectOrEmpty(root.mcp) };
-  delete mcp.goalboard;
-  return replaceTopLevelJsonProperty(contents, root, "mcp", mcp);
 }
 
 function desiredPiEntry(desired: DesiredConnection): Record<string, unknown> {
   return {
     command: desired.launcherPath,
     args: [],
-    env: {
-      GOALBOARD_HOME: desired.goalboardHome,
-      GOALBOARD_MCP_AUDIENCE: "runtime",
-      GOALBOARD_RUNTIME_ID: desired.runtimeId,
-    },
+    env: goalboardProcessEnv(desired),
     lifecycle: "eager",
   };
 }
 
-function inspectPiConfig(contents: string | null, desired: DesiredConnection): ConfigInspection {
-  if (contents == null) return { state: "absent", summary: "未配置 GoalBoard MCP", entryFingerprint: null };
-  const root = parseJsonObject(contents, "Pi Agent MCP 配置");
-  const servers = objectOrEmpty(root.mcpServers);
-  const entry = servers.goalboard;
-  if (entry == null) return { state: "absent", summary: "未配置 GoalBoard MCP", entryFingerprint: null };
-  const expected = desiredPiEntry(desired);
-  if (canonicalJson(entry) === canonicalJson(expected)) {
-    return { state: "current", summary: "当前 GoalBoard MCP 配置", entryFingerprint: digest(canonicalJson(expected)) };
-  }
-  if (/goalboard|GOALBOARD_/i.test(canonicalJson(entry))) {
-    return { state: "legacy", summary: "旧版 GoalBoard MCP 配置", entryFingerprint: digest(canonicalJson(entry)) };
-  }
-  return { state: "conflict", summary: "同名 MCP entry 不属于 GoalBoard", entryFingerprint: digest(canonicalJson(entry)) };
-}
-
-function connectPiConfig(contents: string | null, desired: DesiredConnection): string {
-  const root = contents == null ? {} : parseJsonObject(contents, "Pi Agent MCP 配置");
-  const servers = { ...objectOrEmpty(root.mcpServers), goalboard: desiredPiEntry(desired) };
-  return replaceTopLevelJsonProperty(contents, root, "mcpServers", servers);
-}
-
-function removePiConfig(contents: string | null): string | null {
-  if (contents == null) return null;
-  const root = parseJsonObject(contents, "Pi Agent MCP 配置");
-  const servers = { ...objectOrEmpty(root.mcpServers) };
-  delete servers.goalboard;
-  return replaceTopLevelJsonProperty(contents, root, "mcpServers", servers);
+function jsonMcpHandlers(layout: {
+  parse: (contents: string, label: string) => Record<string, unknown>;
+  label: string;
+  rootKey: string;
+  emptyRoot?: Record<string, unknown>;
+  desiredEntry: (desired: DesiredConnection) => Record<string, unknown>;
+}): Pick<RuntimeAdapter, "inspectConfig" | "connectConfig" | "removeConfig"> {
+  return {
+    inspectConfig(contents, desired) {
+      if (contents == null) return { state: "absent", summary: "未配置 GoalBoard MCP", entryFingerprint: null };
+      const root = layout.parse(contents, layout.label);
+      const entry = objectOrEmpty(root[layout.rootKey]).goalboard;
+      if (entry == null) return { state: "absent", summary: "未配置 GoalBoard MCP", entryFingerprint: null };
+      const expected = layout.desiredEntry(desired);
+      if (canonicalJson(entry) === canonicalJson(expected)) {
+        return { state: "current", summary: "当前 GoalBoard MCP 配置", entryFingerprint: digest(canonicalJson(expected)) };
+      }
+      if (/goalboard|GOALBOARD_/i.test(canonicalJson(entry))) {
+        return { state: "legacy", summary: "旧版 GoalBoard MCP 配置", entryFingerprint: digest(canonicalJson(entry)) };
+      }
+      return { state: "conflict", summary: "同名 MCP entry 不属于 GoalBoard", entryFingerprint: digest(canonicalJson(entry)) };
+    },
+    connectConfig(contents, desired) {
+      const root = contents == null ? { ...(layout.emptyRoot ?? {}) } : layout.parse(contents, layout.label);
+      const bag = { ...objectOrEmpty(root[layout.rootKey]), goalboard: layout.desiredEntry(desired) };
+      return replaceTopLevelJsonProperty(contents, root, layout.rootKey, bag);
+    },
+    removeConfig(contents) {
+      if (contents == null) return null;
+      const root = layout.parse(contents, layout.label);
+      const bag = { ...objectOrEmpty(root[layout.rootKey]) };
+      delete bag.goalboard;
+      return replaceTopLevelJsonProperty(contents, root, layout.rootKey, bag);
+    },
+  };
 }
 
 function replaceTopLevelJsonProperty(

--- a/src/projects/catalog.ts
+++ b/src/projects/catalog.ts
@@ -122,6 +122,7 @@ export interface GoalBoardRuntimeContextBinding {
 }
 
 export interface GoalBoardDesktopPanelRecord {
+  /** Stable panel identity. openDesktopPanel initially sets work_context_id to this same value. */
   panel_id: string;
   project_id: string;
   goal_id: string;
@@ -130,6 +131,7 @@ export interface GoalBoardDesktopPanelRecord {
   launch_args: string[];
   cwd: string | null;
   work_context_id: string;
+  /** Optional host resume alias, not a second panel identity. */
   host_session_id: string | null;
   tab_index: number;
   title: string;

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -1,0 +1,35 @@
+export const SUPPORTED_RUNTIME_IDS = ["codex", "claude-code", "opencode", "pi-agent", "grok-build"] as const;
+export type SupportedRuntimeId = (typeof SUPPORTED_RUNTIME_IDS)[number];
+
+export const RUNTIME_DISPLAY_NAMES = {
+  codex: "Codex",
+  "claude-code": "Claude Code",
+  opencode: "OpenCode",
+  "pi-agent": "Pi Agent",
+  "grok-build": "Grok Build",
+} as const satisfies Record<SupportedRuntimeId, string>;
+
+export const DESKTOP_RUNTIME_KINDS = [...SUPPORTED_RUNTIME_IDS, "generic"] as const;
+export type DesktopRuntimeKind = (typeof DESKTOP_RUNTIME_KINDS)[number];
+
+/** Named runtimes in the add-terminal menu; order is visual, not identity. */
+export const DESKTOP_TUI_MENU_RUNTIME_IDS = [
+  "claude-code",
+  "codex",
+  "opencode",
+  "pi-agent",
+  "grok-build",
+] as const satisfies readonly SupportedRuntimeId[];
+
+export function isSupportedRuntimeId(value: string): value is SupportedRuntimeId {
+  return (SUPPORTED_RUNTIME_IDS as readonly string[]).includes(value);
+}
+
+export function isDesktopRuntimeKind(value: string): value is DesktopRuntimeKind {
+  return (DESKTOP_RUNTIME_KINDS as readonly string[]).includes(value);
+}
+
+export function runtimeDisplayName(runtimeId: string): string {
+  if (runtimeId === "generic") return "自定义命令";
+  return isSupportedRuntimeId(runtimeId) ? RUNTIME_DISPLAY_NAMES[runtimeId] : runtimeId;
+}

--- a/src/web/desktop-shell.ts
+++ b/src/web/desktop-shell.ts
@@ -1,16 +1,7 @@
 import type { IncomingMessage } from "node:http";
+import { cookieValue } from "./http-local.js";
 
 export const DESKTOP_COOKIE = "goalboard_desktop";
-
-function cookieValue(header: string | undefined, name: string): string | undefined {
-  if (!header) return undefined;
-  for (const part of header.split(";")) {
-    const [rawName, ...rest] = part.split("=");
-    if (rawName?.trim() !== name) continue;
-    return rest.join("=").trim();
-  }
-  return undefined;
-}
 
 export function isDesktopShellRequest(request: IncomingMessage, url: URL): boolean {
   const header = request.headers["x-goalboard-desktop"];

--- a/src/web/http-local.ts
+++ b/src/web/http-local.ts
@@ -1,0 +1,35 @@
+import { timingSafeEqual } from "node:crypto";
+import type { IncomingMessage } from "node:http";
+
+export function cookieValue(header: string | undefined, name: string): string | undefined {
+  if (!header) return undefined;
+  for (const part of header.split(";")) {
+    const [rawName, ...rest] = part.split("=");
+    if (rawName?.trim() !== name) continue;
+    return rest.join("=").trim();
+  }
+  return undefined;
+}
+
+export function isLoopbackHostname(hostname: string): boolean {
+  const value = hostname.toLowerCase();
+  return value === "127.0.0.1" || value === "localhost" || value === "[::1]" || value === "::1";
+}
+
+export function requestHost(request: IncomingMessage): string | null {
+  const value = request.headers.host?.trim();
+  if (!value) return null;
+  try {
+    const parsed = new URL(`http://${value}`);
+    return isLoopbackHostname(parsed.hostname) ? parsed.host : null;
+  } catch {
+    return null;
+  }
+}
+
+export function timingSafeTokenEquals(expected: string, actual: string | string[] | null | undefined): boolean {
+  if (typeof actual !== "string") return false;
+  const expectedBytes = Buffer.from(expected);
+  const actualBytes = Buffer.from(actual);
+  return expectedBytes.length === actualBytes.length && timingSafeEqual(expectedBytes, actualBytes);
+}

--- a/src/web/i18n.ts
+++ b/src/web/i18n.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { cookieValue } from "./http-local.js";
 
 export type WebLocale = "zh" | "en";
 
@@ -29,16 +30,6 @@ export function dateTimeLocale(locale: WebLocale = currentLocale()): string {
 
 export function listJoin(values: readonly string[], locale: WebLocale = currentLocale()): string {
   return values.join(locale === "en" ? ", " : "、");
-}
-
-function cookieValue(header: string | undefined, name: string): string | undefined {
-  if (!header) return undefined;
-  for (const part of header.split(";")) {
-    const [rawName, ...rest] = part.split("=");
-    if (rawName?.trim() !== name) continue;
-    return rest.join("=").trim();
-  }
-  return undefined;
 }
 
 export function resolveWebLocale(
@@ -100,7 +91,7 @@ export function renderLocaleSwitch(nextPath: string): string {
   </nav>`;
 }
 
-export function englishCatalogJson(): string {
+function englishCatalogJson(): string {
   return JSON.stringify(EN).replaceAll("<", "\\u003c");
 }
 
@@ -1186,22 +1177,16 @@ export const EN: Record<string, string> = {
   "关闭终端": "Close terminal",
   "自定义命令": "Custom command",
   "终端已退出": "Terminal exited",
-  "没有终端。点右上角「添加终端」在这个 Goal 上打开 TUI。": "No terminal yet. Use Add terminal in the top-right to open a TUI on this Goal.",
   "还没有终端": "No terminal yet",
   "点右上角「添加终端」，在这个 Goal 上打开常用 Runtime 或自定义命令。": "Use Add terminal in the top-right to open a common Runtime or a custom command on this Goal.",
-  "请选择要打开的 TUI": "Choose a TUI to open",
   "在这个 Goal 上打开终端": "Open a terminal on this Goal",
   "标签只属于当前 Goal。打开不会自动发送或领取。": "This tab belongs only to the current Goal. Opening it does not send a prompt or claim the work.",
-  "参数": "Arguments",
-  "工作目录": "Working directory",
-  "继续会话 ID": "Resume session ID",
   "继续会话 ID（可选）": "Resume session ID (optional)",
   "终端面板": "Terminal pane",
   "调整终端宽度": "Resize terminal",
   "打开项目后，Goal 右侧可以添加终端": "After opening a project, add a terminal to the right of the Goal",
   "打开项目后，Goal 详情右侧会出现终端栏。点「添加终端」即可在当前 Goal 上打开 TUI。": "After you open a project, a terminal pane appears on the right of the Goal. Use Add terminal to open a TUI on the current Goal.",
   "打开失败": "Could not open",
-  "桌面终端通道不可用，请从 GoalBoard App 打开。": "The desktop terminal channel is unavailable. Open this page from the GoalBoard App.",
   "正在启动终端…": "Starting terminal…",
   "终端已连接": "Terminal connected",
   "已回到正在运行的终端": "Reconnected to the running terminal",

--- a/src/web/pty-client.ts
+++ b/src/web/pty-client.ts
@@ -291,6 +291,7 @@ if (pane) {
     session.fit.fit();
     const size = session.fit.proposeDimensions();
     const spawn = panel.spawn;
+    if (!spawn) throw new Error(L("打开失败"));
     setStatus(L("正在启动终端…"), "busy");
     await connectPty();
     const spawned = new Promise<PtyServerMessage>((resolve, reject) => {
@@ -313,16 +314,10 @@ if (pane) {
       await sendPty({
         type: "spawn",
         panelId: panel.panel_id,
-        command: spawn?.command ?? panel.launch_command,
-        args: spawn?.args ?? panel.launch_args,
-        cwd: spawn?.cwd ?? panel.cwd,
-        env: spawn?.env ?? {
-          GOALBOARD_PANEL_ID: panel.panel_id,
-          GOALBOARD_GOAL_ID: panel.goal_id,
-          GOALBOARD_WORK_CONTEXT_ID: panel.work_context_id,
-          GOALBOARD_WORK_CONTEXT_STABLE: "true",
-          GOALBOARD_RUNTIME_ID: panel.runtime_kind,
-        },
+        command: spawn.command,
+        args: spawn.args,
+        cwd: spawn.cwd,
+        env: spawn.env,
         cols: Math.max(20, size?.cols ?? 80),
         rows: Math.max(8, size?.rows ?? 24),
       });

--- a/src/web/pty-socket.ts
+++ b/src/web/pty-socket.ts
@@ -1,8 +1,8 @@
-import { timingSafeEqual } from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import type http from "node:http";
 import type { Duplex } from "node:stream";
 import { WebSocketServer, type RawData, type WebSocket } from "ws";
+import { requestHost, timingSafeTokenEquals } from "./http-local.js";
 import { GoalBoardPtyHost, type PtySpawnRequest } from "./pty-host.js";
 
 type ClientMessage =
@@ -11,28 +11,6 @@ type ClientMessage =
   | { type: "write"; panelId: string; data: string }
   | { type: "resize"; panelId: string; cols: number; rows: number }
   | { type: "kill"; panelId: string };
-
-function localHostname(hostname: string): boolean {
-  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
-}
-
-function requestHost(request: IncomingMessage): string | null {
-  const value = request.headers.host?.trim();
-  if (!value) return null;
-  try {
-    const parsed = new URL(`http://${value}`);
-    return localHostname(parsed.hostname) ? parsed.host : null;
-  } catch {
-    return null;
-  }
-}
-
-function tokenMatches(expected: string, actual: string | null | undefined): boolean {
-  if (!actual) return false;
-  const expectedBytes = Buffer.from(expected);
-  const actualBytes = Buffer.from(actual);
-  return expectedBytes.length === actualBytes.length && timingSafeEqual(expectedBytes, actualBytes);
-}
 
 function send(socket: WebSocket, value: unknown): void {
   if (socket.readyState === socket.OPEN) socket.send(JSON.stringify(value));
@@ -109,7 +87,7 @@ export function attachGoalBoardPtySocket(server: http.Server, controlToken: stri
       try {
         const message = parseMessage(raw);
         if (!authed) {
-          if (message.type !== "auth" || !tokenMatches(controlToken, message.token)) {
+          if (message.type !== "auth" || !timingSafeTokenEquals(controlToken, message.token)) {
             send(ws, { type: "error", message: "本地终端通道校验失败" });
             ws.close();
             return;

--- a/src/web/render.ts
+++ b/src/web/render.ts
@@ -24,6 +24,7 @@ import { DEFAULT_GOAL_POLICY } from "../v1/types.js";
 import type { RuntimeIntegrationDetection } from "../install/runtime-integration.js";
 import type { GoalBoardWebServiceDetection } from "../install/web-service.js";
 import { icon, renderIconSprite, type GoalBoardIcon } from "./icons.js";
+import { DESKTOP_TUI_MENU_RUNTIME_IDS, RUNTIME_DISPLAY_NAMES } from "../runtimes.js";
 import {
   L,
   currentLocale,
@@ -2064,7 +2065,7 @@ const STYLES = `
   .tui-menu > strong { font-size: 13px; letter-spacing: -.015em; }
   .tui-menu p { margin: 0; color: var(--muted); font-size: 12px; font-weight: 400; line-height: 1.45; }
   .tui-menu label { display: grid; gap: 4px; color: var(--ink); font-size: 12px; font-weight: 650; }
-  .tui-menu input, .tui-menu select { min-height: 32px; padding: 0 8px; border: 1px solid var(--line-strong); border-radius: 5px; background: #fff; }
+  .tui-menu input { min-height: 32px; padding: 0 8px; border: 1px solid var(--line-strong); border-radius: 5px; background: #fff; }
   .tui-runtime-choices { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
   .tui-runtime-choices button { min-height: 34px; border: 1px solid var(--line-strong); border-radius: 5px; background: #fff; cursor: pointer; text-align: left; padding: 0 10px; font-weight: 650; transition: background .16s ease, border-color .16s ease, color .16s ease; }
   .tui-runtime-choices button[data-tui-kind="generic"] { grid-column: 1 / -1; }
@@ -5360,11 +5361,7 @@ function renderTuiPane(selectedGoalId: string): string {
           <strong>${L("在这个 Goal 上打开终端")}</strong>
           <p>${L("标签只属于当前 Goal。打开不会自动发送或领取。")}</p>
           <div class="tui-runtime-choices">
-            <button type="button" data-tui-kind="claude-code">Claude Code</button>
-            <button type="button" data-tui-kind="codex">Codex</button>
-            <button type="button" data-tui-kind="opencode">OpenCode</button>
-            <button type="button" data-tui-kind="pi-agent">Pi Agent</button>
-            <button type="button" data-tui-kind="grok-build">Grok Build</button>
+            ${DESKTOP_TUI_MENU_RUNTIME_IDS.map((id) => `<button type="button" data-tui-kind="${id}">${RUNTIME_DISPLAY_NAMES[id]}</button>`).join("")}
             <button type="button" data-tui-kind="generic">${L("自定义命令")}</button>
           </div>
           <label data-tui-generic-fields hidden>${L("命令")}<input name="command" type="text" autocomplete="off" placeholder="opencode"></label>

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import os from "node:os";
@@ -11,8 +11,10 @@ import { SqliteGoalBoardStore } from "../v1/store.js";
 import type { GoalPolicy, GoalRelationRecord, RiskRecord } from "../v1/types.js";
 import { GoalBoardProjectCatalog, GoalBoardProjectCatalogError } from "../projects/catalog.js";
 import { desktopAdvancePrompt } from "../desktop/advance-prompt.js";
-import { desktopLaunchSpec, desktopPanelEnv, desktopRuntimeTitle, isDesktopRuntimeKind } from "../desktop/launch.js";
+import { desktopLaunchSpec, desktopPanelSpawnPayload, isDesktopRuntimeKind } from "../desktop/launch.js";
+import { runtimeDisplayName } from "../runtimes.js";
 import { desktopCookieHeaders, isDesktopShellRequest } from "./desktop-shell.js";
+import { isLoopbackHostname, requestHost, timingSafeTokenEquals } from "./http-local.js";
 import { attachGoalBoardPtySocket } from "./pty-socket.js";
 import type {
   GoalBoardProjectRecord,
@@ -22,7 +24,6 @@ import type {
 import {
   RuntimeIntegrationService,
   isSupportedRuntimeId,
-  type SupportedRuntimeId,
 } from "../install/runtime-integration.js";
 import {
   GoalBoardWebServiceManager,
@@ -548,24 +549,6 @@ function servePtyClient(response: ServerResponse): boolean {
   return true;
 }
 
-function desktopPanelSpawn(
-  catalog: GoalBoardProjectCatalog,
-  panel: { panel_id: string; runtime_kind: string; launch_command: string; launch_args: string[]; cwd: string | null; work_context_id: string; goal_id: string },
-) {
-  return {
-    command: panel.launch_command,
-    args: panel.launch_args,
-    cwd: panel.cwd,
-    env: desktopPanelEnv({
-      homeDirectory: catalog.homeDirectory,
-      runtimeId: panel.runtime_kind,
-      panelId: panel.panel_id,
-      workContextId: panel.work_context_id,
-      goalId: panel.goal_id,
-    }),
-  };
-}
-
 const PAGE_CSP = "default-src 'self'; style-src 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'";
 
 async function handleDesktopPanelApi(
@@ -601,7 +584,7 @@ async function handleDesktopPanelApi(
       sendJson(response, 200, {
         panels: catalog.listDesktopPanels(projectId, goalId).map((panel) => ({
           ...panel,
-          spawn: desktopPanelSpawn(catalog, panel),
+          spawn: desktopPanelSpawnPayload({ homeDirectory: catalog.homeDirectory, panel }),
         })),
       });
       return true;
@@ -639,7 +622,7 @@ async function handleDesktopPanelApi(
       });
       sendJson(response, 200, {
         panel,
-        spawn: desktopPanelSpawn(catalog, panel),
+        spawn: desktopPanelSpawnPayload({ homeDirectory: catalog.homeDirectory, panel }),
       });
       return true;
     }
@@ -672,7 +655,7 @@ async function handleDesktopPanelApi(
         return true;
       }
       const opened = catalog.markDesktopPanelOpen(panelId);
-      sendJson(response, 200, { panel: opened, spawn: desktopPanelSpawn(catalog, panel) });
+      sendJson(response, 200, { panel: opened, spawn: desktopPanelSpawnPayload({ homeDirectory: catalog.homeDirectory, panel: opened }) });
       return true;
     }
     return false;
@@ -697,29 +680,6 @@ async function handleDesktopPanelApi(
 
 type LocalMutationState = "in_flight" | "complete";
 
-function localHostname(value: string): boolean {
-  const hostname = value.toLowerCase();
-  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]" || hostname === "::1";
-}
-
-function requestHost(request: IncomingMessage): string | null {
-  const value = request.headers.host?.trim();
-  if (!value) return null;
-  try {
-    const parsed = new URL(`http://${value}`);
-    return localHostname(parsed.hostname) ? parsed.host : null;
-  } catch {
-    return null;
-  }
-}
-
-function controlTokenMatches(expected: string, actual: string | string[] | undefined): boolean {
-  if (typeof actual !== "string") return false;
-  const expectedBytes = Buffer.from(expected);
-  const actualBytes = Buffer.from(actual);
-  return expectedBytes.length === actualBytes.length && timingSafeEqual(expectedBytes, actualBytes);
-}
-
 function authorizeLocalWebRequest(
   request: IncomingMessage,
   response: ServerResponse,
@@ -743,11 +703,11 @@ function authorizeLocalWebRequest(
     sendJson(response, 403, { error: L("本地控制请求校验失败") });
     return false;
   }
-  if (origin.protocol !== "http:" || !localHostname(origin.hostname) || origin.host !== host) {
+  if (origin.protocol !== "http:" || !isLoopbackHostname(origin.hostname) || origin.host !== host) {
     sendJson(response, 403, { error: L("本地控制请求校验失败") });
     return false;
   }
-  if (!controlTokenMatches(controlToken, request.headers["x-goalboard-control-token"])) {
+  if (!timingSafeTokenEquals(controlToken, request.headers["x-goalboard-control-token"])) {
     sendJson(response, 403, { error: L("本地控制请求校验失败") });
     return false;
   }
@@ -816,10 +776,6 @@ function settingsProject(project: GoalBoardProjectRecord): WebSettingsProject {
     data_class: project.data_class,
     created_at: project.created_at,
   };
-}
-
-function runtimeDisplayName(runtimeId: string): string {
-  return desktopRuntimeTitle(runtimeId);
 }
 
 function settingsConnection(
@@ -939,10 +895,6 @@ function installationDiagnostics(
       return { name, path: launcherPath, state: fs.existsSync(launcherPath) ? "ready" : "missing" };
     }),
   };
-}
-
-function supportedRuntimeId(value: string): SupportedRuntimeId | null {
-  return isSupportedRuntimeId(value) ? value : null;
 }
 
 function fixtureWebBoardOptions(options: WebServerOptions): ResolvedWebBoardOptions | null {
@@ -1101,6 +1053,10 @@ async function handleGoalBoardWebRequest(
   controlToken: string,
   mutationKeys: Map<string, LocalMutationState>,
 ): Promise<void> {
+  if (request.method === "GET" && url.pathname === "/desktop/pty-client.js") {
+    servePtyClient(response);
+    return;
+  }
   const resolved = await resolveWebRequest(serverOptions, url.pathname);
       if (resolved.kind === "catalog_index") {
         if (request.method === "GET" && url.pathname === "/settings") {
@@ -1173,10 +1129,14 @@ async function handleGoalBoardWebRequest(
         }
         const runtimePlanMatch = url.pathname.match(/^\/api\/settings\/runtimes\/([^/]+)\/plan$/);
         if (request.method === "POST" && runtimePlanMatch) {
-          const runtimeId = supportedRuntimeId(decodeURIComponent(runtimePlanMatch[1]));
+          const runtimeId = decodeURIComponent(runtimePlanMatch[1]);
+          if (!isSupportedRuntimeId(runtimeId)) {
+            sendJson(response, 400, { error: "Runtime 或接入操作无效" });
+            return;
+          }
           const body = await readBody(request);
           const action = body.action === "connect" || body.action === "remove" ? body.action : null;
-          if (!runtimeId || !action) {
+          if (!action) {
             sendJson(response, 400, { error: "Runtime 或接入操作无效" });
             return;
           }
@@ -1189,11 +1149,11 @@ async function handleGoalBoardWebRequest(
         }
         const runtimeConfirmMatch = url.pathname.match(/^\/api\/settings\/runtimes\/([^/]+)\/confirm$/);
         if (request.method === "POST" && runtimeConfirmMatch) {
-          const runtimeId = supportedRuntimeId(decodeURIComponent(runtimeConfirmMatch[1]));
+          const runtimeId = decodeURIComponent(runtimeConfirmMatch[1]);
           const body = await readBody(request);
           const decision = body.decision === "confirmed" || body.decision === "declined" ? body.decision : null;
           const planId = typeof body.plan_id === "string" ? body.plan_id.trim() : "";
-          if (!runtimeId || !decision || !planId) {
+          if (!isSupportedRuntimeId(runtimeId) || !decision || !planId) {
             sendJson(response, 400, { error: "Runtime 接入确认缺少 plan 或明确决定" });
             return;
           }
@@ -1443,10 +1403,6 @@ async function handleGoalBoardWebRequest(
           }
           return;
         }
-        if (request.method === "GET" && url.pathname === "/desktop/pty-client.js") {
-          servePtyClient(response);
-          return;
-        }
         if (request.method === "GET" && url.pathname === "/health") {
           sendJson(response, 200, { status: "ok", project_count: resolved.projects.length, desktop_tui: true });
           return;
@@ -1489,10 +1445,6 @@ async function handleGoalBoardWebRequest(
       try {
         if (request.method === "GET" && url.pathname === "/health") {
           sendJson(response, 200, { status: "ok", board_id: options.boardId, desktop_tui: true });
-          return;
-        }
-        if (request.method === "GET" && url.pathname === "/desktop/pty-client.js") {
-          servePtyClient(response);
           return;
         }
         if (request.method === "GET" && url.pathname === "/api/board/cursor") {


### PR DESCRIPTION
## Summary
- 把五个 Runtime 的 ID / 显示名收成一张表，TUI 菜单、启动配方和设置页 MCP adapter 共用，避免再各写一份。
- 合并 Claude / OpenCode / Pi 的 JSON MCP 读写，并把 loopback / cookie / token 校验收到同一处；PTY spawn 仍只走面板 API 给出的配方。
- 删掉已无调用的 i18n 文案和残缺 env fallback，行为与接入结果不变。

## Test plan
- [x] `pnpm typecheck`
- [x] `tests/runtime-integration.test.ts`（含 OpenCode / Pi / Grok 官方路径写入）
- [x] `tests/desktop-tui.test.ts`（配方、面板 API、隔离 PTY）
- [x] `tests/web.test.ts`（设置页接入与本机控制门）
- [x] `tests/mcp.test.ts`、`tests/project-catalog.test.ts`、`tests/i18n.test.ts`
- [ ] 浏览器打开项目后点「添加终端」仍能开五个 Runtime 和自定义命令
- [ ] 设置页 detect → plan → confirm 仍写入各 Runtime 官方配置位置


Made with [Cursor](https://cursor.com)