### PR TITLE
Fix pnpm setup in macOS release workflow

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           node-version: 24
 
-      - name: Enable pnpm
-        run: corepack prepare pnpm@11.9.0 --activate
+      - name: Install pnpm
+        run: npm install --global pnpm@11.9.0
 
       - uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
The first dual-architecture run failed before build because Corepack did not persist pnpm onto subsequent GitHub Actions steps. Install the pinned pnpm version globally through npm so both runners can resolve it.\n\nFailed run: https://github.com/adeptify/GoalBoard/actions/runs/32627657927