### PR TITLE
perf: speed up project and Goal loading

### DIFF
--- a/specs/web-view-performance/spec.md
+++ b/specs/web-view-performance/spec.md
@@ -1,0 +1,77 @@
+# Web 项目与 Goal 切换性能修复
+
+## 背景与目标
+
+GoalBoard 已经按需加载单份 Goal 正文，但服务端的单 Goal 接口仍先构建整张 Board 的完整 Web View。大项目打开或切换 Goal 时，服务端会对每个 Goal 重复读取整张快照、重复执行完整可领取性检查；缓存又把 SQLite WAL 文件时间作为版本，数据库仅被打开和关闭也可能造成无效重建。
+
+本次达到“功能可用”：不改变 Goal 状态、权限、页面结构或已有接口语义，让大项目首次打开明显缩短，并让没有数据变化时的项目重开和 Goal 连续切换直接复用已有视图。
+
+## 当前行为与证据
+
+- Footballnia：155 个 Goal、1018 条关系、2596 条事件。
+- 单次 `store.snapshot` 约 0.10 秒。
+- 对 155 个 Goal 逐个调用 `getGoalWorkState` 约 5.23 秒。
+- 对 155 个 Goal 逐个调用 `explainGoal` 约 2.74 秒。
+- `buildGoalBoardWebView` 约 8.63 秒，最终 HTML renderer 约 0.07 秒。
+- 实际项目请求出现过 13.7–68.8 秒首字节等待。
+- `/api/goals/:goal_id/document` 仍调用 `cachedGoalBoardWebView`；缓存键包含数据库和 WAL 的大小、修改时间。
+
+## 范围
+
+- Web View 缓存由 Board 的权威事件游标、主数据库文件版本和影响展示的路由选项失效；明确忽略 WAL 生命周期。
+- Coordinator 提供一次快照内批量派生全部 Goal 工作状态的只读能力。
+- Web View 构建不再为了读取 resolved policy 对每个 Goal 执行一次完整 `explainGoal`。
+- 将构建阶段反复按 Goal 扫描的数据预先建立索引，避免随项目增长形成不必要的重复扫描。
+- 为缓存稳定性、状态一致性和大 Board 构建路径补充回归测试。
+
+## 非目标
+
+- 不改变 Goal Contract、状态机、依赖、风险、Claim、Run 或 Review 语义。
+- 不改变页面视觉、文案或客户端路由。
+- 不引入新数据库、后台任务、前端框架或持久化缓存。
+- 不把所有 Coordinator 查询一次性重写成新的查询引擎。
+- 不用脆弱的固定毫秒数作为 CI 成败标准。
+
+## 方案与关键决策
+
+1. 以 Board 事件游标作为首要 Web View 内容版本。GoalBoard 的规范写入都会追加事件；同时保留主数据库文件大小与修改时间，兼容存量的直接 SQLite 写入。WAL 文件是 SQLite 实现细节，不能作为用户数据变更信号。
+   请求完成并关闭只读连接后，将缓存记录对齐到检查点后的主数据库版本；该连接已经读取过检查点前的 WAL 内容，因此不需要仅因 WAL 合并到主文件再重建一次。
+2. 新增 Coordinator 批量只读接口：一次读取 BoardSnapshot，再为所有 Goal 派生 canonical work state。单 Goal 接口保持兼容并复用相同内部路径。
+3. 新增只读 resolved policy 接口，Web 展示策略时不再通过 `explainGoal` 顺带执行依赖、风险、Claim 和影响冲突检查。
+4. Web 构建先按 `goal_id`、`risk_id`、对象 ID 建立 Map/Set 索引，再组装各 Goal 的详情。结果结构保持不变。
+5. 缓存修复负责“没有变化时不重算”；批量状态与索引负责“首次构建也足够快”。两者缺一不可。
+
+## 输入、输出与依赖
+
+- 输入：项目数据库路径、Board ID、事件游标、Web 路由展示选项。
+- 输出：与现有 `GoalBoardWebView` 完全兼容的只读视图和单 Goal HTML fragment。
+- 依赖：`SqliteGoalBoardStore.snapshot/eventCursor`、Coordinator canonical 状态派生、现有 Web renderer。
+
+## 文件与模块边界
+
+- `src/v1/coordinator.ts`：批量工作状态与只读策略入口；状态规则仍只有一套。
+- `src/web/server.ts`：稳定缓存键、索引化 Web View 组装。
+- `tests/v1.test.ts`：批量与单 Goal 工作状态一致性。
+- `tests/web.test.ts`：缓存无数据变化时保持命中，事件变化后失效；Web 输出不回归。
+
+## 验收标准
+
+1. 同一 Board 无新事件、主数据库无变化时，重复页面请求和 Goal 文档请求不重建 Web View；仅打开或关闭 WAL 不触发重建。
+2. Board 追加事件或存量路径直接更新主数据库后，下一次读取会重建并展示新事实。
+3. 批量工作状态与逐 Goal 查询对所有状态字段保持一致。
+4. Web View 不再逐 Goal 调用 `store.snapshot` 或 `explainGoal`。
+5. Footballnia 的 `buildGoalBoardWebView` 从约 8.63 秒降到 2 秒以内；连续 Goal 文档请求在本机达到接近即时响应。
+6. `pnpm typecheck`、定向 V1/Web 测试和完整测试通过。
+
+## 验证命令
+
+- `pnpm typecheck`
+- `node --import tsx --test tests/v1.test.ts tests/web.test.ts`
+- `pnpm test`
+- 用 Footballnia 数据库重复测量 `buildGoalBoardWebView`、项目页面 TTFB 和连续 Goal fragment TTFB。
+
+## 假设与风险
+
+- 规范写入应追加 Board 事件；主数据库文件版本只为存量直接 SQLite 写入提供兼容兜底，不再通过 WAL 时间猜测内容变化。
+- 批量派生仍可能对部分可执行 Goal 做规则查询；本次先移除重复快照和重复完整解释，不扩张为 Coordinator 全量查询架构重写。
+- 真实大项目性能用于人工验收，不把机器相关的绝对耗时写成不稳定测试。

--- a/src/v1/coordinator.ts
+++ b/src/v1/coordinator.ts
@@ -4,6 +4,7 @@ import { SqliteGoalBoardStore, mapSqliteClaim, sqliteJson } from "./store.js";
 import {
   DEFAULT_GOAL_POLICY,
   type AvailableGoal,
+  type BoardSnapshot,
   type ClaimDecision,
   type ClaimRecord,
   type ClaimRunDecision,
@@ -230,6 +231,7 @@ interface EvaluationInput {
   goalModeAttestation: boolean;
   strengthenPolicy?: Partial<GoalPolicy>;
   now: string;
+  snapshot?: BoardSnapshot;
 }
 
 interface Evaluation {
@@ -2307,6 +2309,27 @@ export class GoalBoardCoordinator {
     const goal = snapshot.goals.find((item) => item.goal_id === input.goal_id);
     if (!goal) throw new GoalBoardV1Error("goal.not_found", `找不到这个 Goal: ${input.goal_id}`);
     return this.deriveGoalWorkState(input.board_id, goal, snapshot, this.clock().toISOString());
+  }
+
+  /**
+   * Read every canonical Goal work state from one Board snapshot. Web surfaces
+   * need the whole navigator, so repeating `getGoalWorkState` would otherwise
+   * reload the same Board once per Goal.
+   */
+  getGoalWorkStates(input: { board_id: string }): GoalWorkStateView[] {
+    this.requireBoard(input.board_id);
+    const snapshot = this.store.snapshot(input.board_id);
+    const now = this.clock().toISOString();
+    return snapshot.goals.map((goal) =>
+      this.deriveGoalWorkState(input.board_id, goal, snapshot, now),
+    );
+  }
+
+  /** Read the canonical effective policy without running a full readiness evaluation. */
+  getResolvedGoalPolicy(input: { board_id: string; goal_id: string }): GoalPolicy {
+    this.requireBoard(input.board_id);
+    this.requireGoalOnBoard(input.board_id, input.goal_id);
+    return this.resolvePolicy(input.board_id, input.goal_id);
   }
 
   explainGoal(input: ReadyQuery & { goal_id: string }): ExplainGoalResult {
@@ -7842,7 +7865,7 @@ export class GoalBoardCoordinator {
       goal.acceptance_criteria.length === 0;
     if (needsClarification) {
       if (activeRun?.role === "clarifier") return this.workStateFromRun(base, activeRun);
-      const reasons = this.workStatePhaseReasons(boardId, goal.goal_id, "clarifier", now);
+      const reasons = this.workStatePhaseReasons(boardId, goal.goal_id, "clarifier", now, snapshot);
       return {
         ...base,
         work_state: reasons.length > 0 ? "clarification_blocked" : "clarification_pending",
@@ -7884,7 +7907,7 @@ export class GoalBoardCoordinator {
     if (activeRun) return this.workStateFromRun(base, activeRun);
 
     if (goal.validity_state === "needs_revalidation") {
-      const reasons = this.workStatePhaseReasons(boardId, goal.goal_id, "revalidator", now);
+      const reasons = this.workStatePhaseReasons(boardId, goal.goal_id, "revalidator", now, snapshot);
       return {
         ...base,
         work_state: reasons.length > 0 ? "revalidation_blocked" : "revalidation_pending",
@@ -7898,7 +7921,7 @@ export class GoalBoardCoordinator {
         .map((obligation) => this.reviewActionFor(obligation))
         .find((candidate): candidate is AvailableAction => candidate !== null);
       const reasons = action
-        ? this.workStatePhaseReasons(boardId, goal.goal_id, action.role, now)
+        ? this.workStatePhaseReasons(boardId, goal.goal_id, action.role, now, snapshot)
         : [
             reason(
               "review.user_approval_required",
@@ -7915,7 +7938,7 @@ export class GoalBoardCoordinator {
       };
     }
 
-    const reasons = this.workStatePhaseReasons(boardId, goal.goal_id, "executor", now);
+    const reasons = this.workStatePhaseReasons(boardId, goal.goal_id, "executor", now, snapshot);
     return {
       ...base,
       work_state: reasons.length > 0 ? "execution_blocked" : "execution_pending",
@@ -8071,6 +8094,7 @@ export class GoalBoardCoordinator {
     goalId: string,
     role: ClaimRole,
     now: string,
+    snapshot?: BoardSnapshot,
   ): DecisionReason[] {
     const policy = this.resolvePolicy(boardId, goalId);
     return this.evaluate({
@@ -8081,6 +8105,7 @@ export class GoalBoardCoordinator {
       capabilities: policy.required_capabilities,
       goalModeAttestation: true,
       now,
+      snapshot,
     }).reasons.filter((item) => !item.code.startsWith("claim."));
   }
 
@@ -8320,9 +8345,11 @@ export class GoalBoardCoordinator {
   }
 
   private evaluate(input: EvaluationInput): Evaluation {
-    const goal = this.store.getGoal(input.goalId);
+    const goal = input.snapshot
+      ? input.snapshot.goals.find((item) => item.goal_id === input.goalId) ?? null
+      : this.store.getGoal(input.goalId);
     const policy = this.resolvePolicy(input.boardId, input.goalId, input.strengthenPolicy);
-    const surfaces = this.goalImpacts(input.boardId, input.goalId);
+    const surfaces = this.goalImpacts(input.boardId, input.goalId, input.snapshot);
     const reasons: DecisionReason[] = [];
     if (!goal || goal.board_id !== input.boardId) {
       reasons.push(reason("goal.not_found", "goal", input.goalId, "找不到这个 Goal"));
@@ -8704,10 +8731,14 @@ export class GoalBoardCoordinator {
     return false;
   }
 
-  private goalImpacts(boardId: string, goalId: string): ImpactBindingRecord[] {
-    return this.store
-      .snapshot(boardId)
-      .impacts.filter((impact) => impact.goal_id === goalId && impact.state !== "inactive");
+  private goalImpacts(
+    boardId: string,
+    goalId: string,
+    snapshot?: BoardSnapshot,
+  ): ImpactBindingRecord[] {
+    return (snapshot ?? this.store.snapshot(boardId)).impacts.filter(
+      (impact) => impact.goal_id === goalId && impact.state !== "inactive",
+    );
   }
 
   private dependencySummary(boardId: string, goalId: string): string[] {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -125,17 +125,13 @@ interface GoalBoardWebViewCacheEntry {
 
 type GoalBoardWebViewCache = Map<string, GoalBoardWebViewCacheEntry>;
 
-function sqliteDatabaseVersion(databasePath: string): string {
-  return [databasePath, `${databasePath}-wal`]
-    .map((filePath) => {
-      try {
-        const stat = fs.statSync(filePath, { bigint: true });
-        return `${stat.size}:${stat.mtimeNs}`;
-      } catch {
-        return "missing";
-      }
-    })
-    .join("|");
+function sqliteMainDatabaseVersion(databasePath: string): string {
+  try {
+    const stat = fs.statSync(databasePath, { bigint: true });
+    return `${stat.size}:${stat.mtimeNs}`;
+  } catch {
+    return "missing";
+  }
 }
 
 type ResolvedWebRequest =
@@ -381,17 +377,16 @@ export function buildGoalBoardWebView(
     ...risk,
     goal_ids: riskGoalIds.get(risk.risk_id) ?? [],
   }));
+  const workStates = new Map(
+    coordinator.getGoalWorkStates({ board_id: options.boardId }).map((state) => [state.goal_id, state]),
+  );
   const allGoals = snapshot.goals.map((goal) => {
-    const workState = coordinator.getGoalWorkState({
-      board_id: options.boardId,
-      goal_id: goal.goal_id,
-    });
+    const workState = workStates.get(goal.goal_id);
+    if (!workState) throw new Error(`Goal 工作状态不存在: ${goal.goal_id}`);
     const activeClaim = workState.active_claim;
-    const explanation = coordinator.explainGoal({
+    const resolvedPolicy = coordinator.getResolvedGoalPolicy({
       board_id: options.boardId,
       goal_id: goal.goal_id,
-      actor_id: "web-observer",
-      goal_mode_attestation: true,
     });
     const status: WebGoalStatus = goalPresentationState(
       workState.work_state,
@@ -519,7 +514,7 @@ export function buildGoalBoardWebView(
         (item) => item.goal_id == null || item.goal_id === goal.goal_id,
       ),
       events: events.filter((item) => relatedObjectIds.has(item.object_id)),
-      resolved_policy: explanation.resolved_policy,
+      resolved_policy: resolvedPolicy,
       passed_criteria: [...passedCriteria],
       pending_reviews: pendingReviews,
     };
@@ -564,14 +559,14 @@ export function buildGoalBoardWebView(
   };
 }
 
-function cachedGoalBoardWebView(
+export function cachedGoalBoardWebView(
   cache: GoalBoardWebViewCache,
   store: SqliteGoalBoardStore,
   coordinator: GoalBoardCoordinator,
   options: WebViewOptions,
 ): GoalBoardWebView {
   const cursor = store.eventCursor(options.boardId);
-  const databaseVersion = sqliteDatabaseVersion(options.databasePath);
+  const databaseVersion = sqliteMainDatabaseVersion(options.databasePath);
   const optionsFingerprint = JSON.stringify({
     board_id: options.boardId,
     demo: Boolean(options.demo),
@@ -589,6 +584,14 @@ function cachedGoalBoardWebView(
   const view = buildGoalBoardWebView(store, coordinator, options);
   cache.set(options.databasePath, { cursor, databaseVersion, optionsFingerprint, view });
   return view;
+}
+
+function alignCachedMainDatabaseVersion(
+  cache: GoalBoardWebViewCache,
+  databasePath: string,
+): void {
+  const cached = cache.get(databasePath);
+  if (cached) cached.databaseVersion = sqliteMainDatabaseVersion(databasePath);
 }
 
 function sendJson(response: ServerResponse, status: number, value: unknown): void {
@@ -1644,6 +1647,12 @@ async function handleGoalBoardWebRequest(
         () => new Date(),
         readPersonalPlanningMethodPacks(serverOptions.homeDirectory),
       );
+      let webViewWasRead = false;
+      const readWebView = (): GoalBoardWebView => {
+        const view = cachedGoalBoardWebView(webViewCache, store, coordinator, options);
+        webViewWasRead = true;
+        return view;
+      };
       try {
         if (request.method === "GET" && url.pathname === "/settings/rules") {
           response.writeHead(200, {
@@ -1653,7 +1662,7 @@ async function handleGoalBoardWebRequest(
             ...desktopCookieHeaders(request, url),
           });
           response.end(renderGoalBoardProjectSettings(
-            cachedGoalBoardWebView(webViewCache, store, coordinator, options),
+            readWebView(),
             controlToken,
             isDesktopShellRequest(request, url),
           ));
@@ -1661,7 +1670,7 @@ async function handleGoalBoardWebRequest(
         }
         const projectPlanningMethodMatch = url.pathname.match(/^\/settings\/planning\/([^/]+)(?:\/(edit))?$/);
         if (request.method === "GET" && projectPlanningMethodMatch) {
-          const view = cachedGoalBoardWebView(webViewCache, store, coordinator, options);
+          const view = readWebView();
           const methodId = decodeURIComponent(projectPlanningMethodMatch[1]);
           const method = methodId === "new"
             ? null
@@ -1688,7 +1697,7 @@ async function handleGoalBoardWebRequest(
           return;
         }
         if (request.method === "GET" && url.pathname === "/settings/planning") {
-          const view = cachedGoalBoardWebView(webViewCache, store, coordinator, options);
+          const view = readWebView();
           response.writeHead(200, {
             "content-type": "text/html; charset=utf-8",
             "cache-control": "no-store",
@@ -1798,7 +1807,7 @@ async function handleGoalBoardWebRequest(
           return;
         }
         if (request.method === "GET" && url.pathname === "/api/board") {
-          sendJson(response, 200, cachedGoalBoardWebView(webViewCache, store, coordinator, options));
+          sendJson(response, 200, readWebView());
           return;
         }
         if (options.project?.project_id) {
@@ -1829,7 +1838,7 @@ async function handleGoalBoardWebRequest(
             sendJson(response, 400, { error: "Goal 正文集合无效" });
             return;
           }
-          const view = cachedGoalBoardWebView(webViewCache, store, coordinator, options);
+          const view = readWebView();
           const fragment = renderGoalDocumentFragment(view, goalId, collection);
           if (!fragment) {
             sendJson(response, 404, { error: `找不到这个 Goal: ${goalId}` });
@@ -2842,7 +2851,7 @@ async function handleGoalBoardWebRequest(
               return;
             }
           }
-          const view = cachedGoalBoardWebView(webViewCache, store, coordinator, options);
+          const view = readWebView();
           const requestedArchived = requestedGoalId
             ? view.archived_goals.some((item) => item.goal.goal_id === requestedGoalId)
             : false;
@@ -2886,6 +2895,7 @@ async function handleGoalBoardWebRequest(
         sendJson(response, 404, { error: L("页面或接口不存在") });
       } finally {
         store.close();
+        if (webViewWasRead) alignCachedMainDatabaseVersion(webViewCache, options.databasePath);
       }
 }
 

--- a/tests/v1.test.ts
+++ b/tests/v1.test.ts
@@ -382,6 +382,51 @@ function contractFieldSources(runId: string) {
   }));
 }
 
+test("batch Goal work states match canonical single-Goal reads", () => {
+  const { store, coordinator } = fixture();
+  try {
+    createLeaf(coordinator, "foundation");
+    createLeaf(coordinator, "delivery");
+    coordinator.addRelation(
+      "board-1",
+      {
+        from_goal_id: "delivery",
+        to_goal_id: "foundation",
+        type: "depends_on",
+        state: "active",
+        reason: "交付依赖底层能力",
+      },
+      { actor_id: "user-1", idempotency_key: "batch-state-dependency" },
+    );
+    coordinator.createGoal(
+      "board-1",
+      {
+        goal_id: "rough-idea",
+        title: "继续澄清需求",
+        outcome: "",
+        why: "",
+        business_logic: "",
+        definition_state: "draft",
+        decomposition_state: "abstract",
+        acceptance_criteria: [],
+      },
+      { actor_id: "user-1", idempotency_key: "batch-state-draft" },
+    );
+
+    const batch = new Map(
+      coordinator.getGoalWorkStates({ board_id: "board-1" }).map((state) => [state.goal_id, state]),
+    );
+    for (const goal of store.listGoals("board-1")) {
+      assert.deepEqual(
+        batch.get(goal.goal_id),
+        coordinator.getGoalWorkState({ board_id: "board-1", goal_id: goal.goal_id }),
+      );
+    }
+  } finally {
+    store.close();
+  }
+});
+
 test("public CLI exposes install, service, demo, uninstall, and GoalBoard V1 plus explicit V3 import", async () => {
   const logs: string[] = [];
   const errors: string[] = [];

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../src/web/render.js";
 import {
   buildGoalBoardWebView,
+  cachedGoalBoardWebView,
   createGoalBoardWebServer as createBaseGoalBoardWebServer,
 } from "../src/web/server.js";
 
@@ -124,6 +125,61 @@ function webFixture() {
   seedDemoBoard(databasePath);
   return { databasePath };
 }
+
+test("Web View cache follows Board events and main DB changes instead of SQLite WAL lifecycle", () => {
+  const { databasePath } = webFixture();
+  const cache = new Map() as Parameters<typeof cachedGoalBoardWebView>[0];
+  const options = { databasePath, boardId: DEMO_BOARD_ID, demo: true };
+
+  const firstStore = new SqliteGoalBoardStore(databasePath);
+  const first = cachedGoalBoardWebView(
+    cache,
+    firstStore,
+    new GoalBoardCoordinator(firstStore),
+    options,
+  );
+  firstStore.close();
+
+  const reopenedStore = new SqliteGoalBoardStore(databasePath);
+  try {
+    const coordinator = new GoalBoardCoordinator(reopenedStore);
+    const unchanged = cachedGoalBoardWebView(cache, reopenedStore, coordinator, options);
+    assert.strictEqual(unchanged, first, "opening the SQLite WAL must not invalidate an unchanged Board");
+
+    coordinator.createGoal(
+      DEMO_BOARD_ID,
+      {
+        goal_id: "CACHE-EVENT",
+        title: "通过事件使 Web View 失效",
+        outcome: "",
+        why: "",
+        business_logic: "",
+        definition_state: "draft",
+        decomposition_state: "abstract",
+        acceptance_criteria: [],
+      },
+      { actor_id: "test-user", idempotency_key: "web-cache-event" },
+    );
+    const changed = cachedGoalBoardWebView(cache, reopenedStore, coordinator, options);
+    assert.notStrictEqual(changed, first);
+    assert.ok(changed.goals.some((item) => item.goal.goal_id === "CACHE-EVENT"));
+
+    const cursorBeforeDirectWrite = reopenedStore.eventCursor(DEMO_BOARD_ID);
+    reopenedStore.db
+      .prepare("UPDATE goals SET title = ? WHERE goal_id = ?")
+      .run("没有事件的存量写入", "CACHE-EVENT");
+    reopenedStore.db.pragma("wal_checkpoint(TRUNCATE)");
+    assert.equal(reopenedStore.eventCursor(DEMO_BOARD_ID), cursorBeforeDirectWrite);
+    const directlyChanged = cachedGoalBoardWebView(cache, reopenedStore, coordinator, options);
+    assert.notStrictEqual(directlyChanged, changed);
+    assert.equal(
+      directlyChanged.goals.find((item) => item.goal.goal_id === "CACHE-EVENT")?.goal.title,
+      "没有事件的存量写入",
+    );
+  } finally {
+    reopenedStore.close();
+  }
+});
 
 async function webProjectCatalogFixture() {
   const homeDirectory = mkdtempSync(join(tmpdir(), "goalboard-web-project-catalog-"));


### PR DESCRIPTION
## Summary
- batch canonical Goal work-state reads from one Board snapshot
- stop rebuilding full readiness explanations for every Web Goal
- keep Web View caching stable across WAL lifecycle while preserving event and direct-DB invalidation
- add regression coverage and a performance contract

## Verification
- pnpm typecheck
- pnpm test (209/209)
- Footballnia cold project response ~0.31s in an isolated fresh service
- Goal document switching ~16–22ms after project load