### PR TITLE
perf: streamline Goal web view loading

### DIFF
--- a/specs/web-view-performance/spec.md
+++ b/specs/web-view-performance/spec.md
@@ -4,7 +4,7 @@
 
 GoalBoard 已经按需加载单份 Goal 正文，但服务端的单 Goal 接口仍先构建整张 Board 的完整 Web View。大项目打开或切换 Goal 时，服务端会对每个 Goal 重复读取整张快照、重复执行完整可领取性检查；缓存又把 SQLite WAL 文件时间作为版本，数据库仅被打开和关闭也可能造成无效重建。
 
-本次达到“功能可用”：不改变 Goal 状态、权限、页面结构或已有接口语义，让大项目首次打开明显缩短，并让没有数据变化时的项目重开和 Goal 连续切换直接复用已有视图。
+本次达到“内部完整”：不改变 Goal 状态、权限、数据结构或已有写入语义，让大项目首次打开和 Goal 连续切换保持轻量，并修复浏览器前进后退时 URL 与选中 Goal 不一致的问题。
 
 ## 当前行为与证据
 
@@ -15,53 +15,61 @@ GoalBoard 已经按需加载单份 Goal 正文，但服务端的单 Goal 接口�
 - `buildGoalBoardWebView` 约 8.63 秒，最终 HTML renderer 约 0.07 秒。
 - 实际项目请求出现过 13.7–68.8 秒首字节等待。
 - `/api/goals/:goal_id/document` 仍调用 `cachedGoalBoardWebView`；缓存键包含数据库和 WAL 的大小、修改时间。
+- 服务端缓存优化后，Footballnia 单 Goal 接口已降到约 0.02–0.17 秒，但正文仍有约 0.35–1.33 MB；隐藏的“完整记录”和全部事件 payload 会在普通 Goal 切换时一并生成和解析。
+- 从 `/goals/:id` 后退到项目根路径时，客户端没有恢复根历史项对应的 Goal，导致 URL 与页面内容不一致。
 
 ## 范围
 
-- Web View 缓存由 Board 的权威事件游标、主数据库文件版本和影响展示的路由选项失效；明确忽略 WAL 生命周期。
+- Web View 缓存只由 Board 的权威事件游标和影响展示的路由选项失效；不再通过 SQLite 文件时间猜测内容变化。
 - Coordinator 提供一次快照内批量派生全部 Goal 工作状态的只读能力。
 - Web View 构建不再为了读取 resolved policy 对每个 Goal 执行一次完整 `explainGoal`。
-- 将构建阶段反复按 Goal 扫描的数据预先建立索引，避免随项目增长形成不必要的重复扫描。
+- Web View 构建与批量状态派生共享同一份 BoardSnapshot，避免一次页面读取混用两个时点的事实。
+- 普通 Goal 正文不再预渲染“完整记录”；用户打开记录 Tab 时再按需读取同一份只读事实。
+- 浏览器根历史项保存初始 Goal，前进后退始终保持 URL、Tree 选中项和正文一致。
 - 为缓存稳定性、状态一致性和大 Board 构建路径补充回归测试。
 
 ## 非目标
 
 - 不改变 Goal Contract、状态机、依赖、风险、Claim、Run 或 Review 语义。
-- 不改变页面视觉、文案或客户端路由。
+- 不重新设计页面视觉，不改变已有导航或 URL 结构；只补充记录加载与失败状态。
 - 不引入新数据库、后台任务、前端框架或持久化缓存。
 - 不把所有 Coordinator 查询一次性重写成新的查询引擎。
+- 不承诺兼容绕过 Coordinator、又不追加事件的裸 SQL 写入；这不是 GoalBoard 的正式写入契约。
 - 不用脆弱的固定毫秒数作为 CI 成败标准。
 
 ## 方案与关键决策
 
-1. 以 Board 事件游标作为首要 Web View 内容版本。GoalBoard 的规范写入都会追加事件；同时保留主数据库文件大小与修改时间，兼容存量的直接 SQLite 写入。WAL 文件是 SQLite 实现细节，不能作为用户数据变更信号。
-   请求完成并关闭只读连接后，将缓存记录对齐到检查点后的主数据库版本；该连接已经读取过检查点前的 WAL 内容，因此不需要仅因 WAL 合并到主文件再重建一次。
-2. 新增 Coordinator 批量只读接口：一次读取 BoardSnapshot，再为所有 Goal 派生 canonical work state。单 Goal 接口保持兼容并复用相同内部路径。
-3. 新增只读 resolved policy 接口，Web 展示策略时不再通过 `explainGoal` 顺带执行依赖、风险、Claim 和影响冲突检查。
-4. Web 构建先按 `goal_id`、`risk_id`、对象 ID 建立 Map/Set 索引，再组装各 Goal 的详情。结果结构保持不变。
-5. 缓存修复负责“没有变化时不重算”；批量状态与索引负责“首次构建也足够快”。两者缺一不可。
+1. 以 Board 事件游标作为 Web View 唯一内容版本。GoalBoard 的规范写入都会在同一事务中追加事件；SQLite 主文件与 WAL 的时间、大小都不是产品事实版本。若未来需要支持外部写入，应增加事务内递增的显式 revision，而不是恢复文件时间兜底。
+2. Coordinator 批量只读接口接受已经读取的 BoardSnapshot，并在所有 Goal 状态派生中复用它。单 Goal 接口保持兼容并复用相同内部路径。
+3. Web 展示策略仍通过 canonical policy resolver 读取，不再通过 `explainGoal` 顺带执行依赖、风险、Claim 和影响冲突检查。本次不为微小查询耗时扩张新的查询引擎。
+4. Goal 正文继续使用现有 renderer；仅把“完整记录”替换成可访问的加载占位，并新增同项目、同 Goal、同 collection 的只读 records fragment。加载完成后仍呈现原来的全部记录，不删减数据。
+5. 页面初始化时用 `history.replaceState` 给根历史项记录初始 Goal；`popstate` 对 `/goals/:id` 和项目根路径都调用同一 `selectGoal` 路径。
+6. 缓存负责“没有事件时不重算”，单快照批量状态负责“首次构建不重复读 Board”，记录按需加载负责“普通点击不解析不看的历史账本”。
 
 ## 输入、输出与依赖
 
-- 输入：项目数据库路径、Board ID、事件游标、Web 路由展示选项。
-- 输出：与现有 `GoalBoardWebView` 完全兼容的只读视图和单 Goal HTML fragment。
+- 输入：项目数据库路径、Board ID、事件游标、Web 路由展示选项、当前 Goal 与记录 collection。
+- 输出：与现有 `GoalBoardWebView` 完全兼容的只读视图、单 Goal HTML fragment 和按需 records fragment。
 - 依赖：`SqliteGoalBoardStore.snapshot/eventCursor`、Coordinator canonical 状态派生、现有 Web renderer。
 
 ## 文件与模块边界
 
 - `src/v1/coordinator.ts`：批量工作状态与只读策略入口；状态规则仍只有一套。
-- `src/web/server.ts`：稳定缓存键、索引化 Web View 组装。
+- `src/web/server.ts`：事件游标缓存键、单快照 Web View 组装、records fragment 路由。
+- `src/web/render.ts`：浏览器历史一致性、记录按需加载；原有记录 renderer 保持唯一。
 - `tests/v1.test.ts`：批量与单 Goal 工作状态一致性。
 - `tests/web.test.ts`：缓存无数据变化时保持命中，事件变化后失效；Web 输出不回归。
 
 ## 验收标准
 
-1. 同一 Board 无新事件、主数据库无变化时，重复页面请求和 Goal 文档请求不重建 Web View；仅打开或关闭 WAL 不触发重建。
-2. Board 追加事件或存量路径直接更新主数据库后，下一次读取会重建并展示新事实。
+1. 同一 Board 无新事件时，重复页面请求和 Goal 文档请求不重建 Web View；SQLite 文件生命周期不参与缓存判断。
+2. Board 通过正式写入路径追加事件后，下一次读取会重建并展示新事实。
 3. 批量工作状态与逐 Goal 查询对所有状态字段保持一致。
 4. Web View 不再逐 Goal 调用 `store.snapshot` 或 `explainGoal`。
-5. Footballnia 的 `buildGoalBoardWebView` 从约 8.63 秒降到 2 秒以内；连续 Goal 文档请求在本机达到接近即时响应。
-6. `pnpm typecheck`、定向 V1/Web 测试和完整测试通过。
+5. 普通 Goal 页面和 `/document` fragment 不包含完整记录账本；打开记录 Tab 后仍能看到原有完整内容。
+6. 从两个 Goal 连续后退到项目根路径时，URL、Tree 选中项和正文恢复到根历史项的初始 Goal；前进同样一致。
+7. Footballnia 的 `buildGoalBoardWebView` 保持 2 秒以内；连续 Goal 文档请求在本机达到接近即时响应，普通正文体积明显下降。
+8. `pnpm typecheck`、定向 V1/Web 测试、完整测试和真实浏览器回归通过。
 
 ## 验证命令
 
@@ -72,6 +80,7 @@ GoalBoard 已经按需加载单份 Goal 正文，但服务端的单 Goal 接口�
 
 ## 假设与风险
 
-- 规范写入应追加 Board 事件；主数据库文件版本只为存量直接 SQLite 写入提供兼容兜底，不再通过 WAL 时间猜测内容变化。
+- 规范写入必须追加 Board 事件；没有事件的裸 SQL 更新不会触发 Web 缓存失效，也不属于受支持的产品写入路径。
 - 批量派生仍可能对部分可执行 Goal 做规则查询；本次先移除重复快照和重复完整解释，不扩张为 Coordinator 全量查询架构重写。
+- 记录 Tab 首次打开仍可能读取较大的历史账本；本次先消除日常切换成本，不改变记录完整性或引入分页语义。
 - 真实大项目性能用于人工验收，不把机器相关的绝对耗时写成不稳定测试。

--- a/src/v1/coordinator.ts
+++ b/src/v1/coordinator.ts
@@ -2316,9 +2316,12 @@ export class GoalBoardCoordinator {
    * need the whole navigator, so repeating `getGoalWorkState` would otherwise
    * reload the same Board once per Goal.
    */
-  getGoalWorkStates(input: { board_id: string }): GoalWorkStateView[] {
+  getGoalWorkStates(input: { board_id: string; snapshot?: BoardSnapshot }): GoalWorkStateView[] {
     this.requireBoard(input.board_id);
-    const snapshot = this.store.snapshot(input.board_id);
+    const snapshot = input.snapshot ?? this.store.snapshot(input.board_id);
+    if (snapshot.board.board_id !== input.board_id) {
+      throw new GoalBoardV1Error("board.snapshot_mismatch", "BoardSnapshot 不属于请求的 Board");
+    }
     const now = this.clock().toISOString();
     return snapshot.goals.map((goal) =>
       this.deriveGoalWorkState(input.board_id, goal, snapshot, now),

--- a/src/web/i18n.ts
+++ b/src/web/i18n.ts
@@ -1851,6 +1851,10 @@ Object.assign(EN, {
 });
 
 Object.assign(EN, {
+  "正在载入完整记录…": "Loading complete records…",
+  "无法读取这条 Goal 的完整记录": "Could not read this Goal's complete records",
+  "Goal 记录响应不完整": "The Goal records response is incomplete",
+  "无法载入完整记录": "Could not load complete records",
   "当前终端归属": "This terminal belongs to",
   "打开这个子 Goal": "Open this child Goal",
   "请先选择一个具体的子 Goal": "Choose a specific child Goal first",

--- a/src/web/render.ts
+++ b/src/web/render.ts
@@ -3562,7 +3562,7 @@ unreviewed and undocumented is unfinished; this build ends with the finish revie
         ${renderGoalFactors(item, view)}
       </div>
       <div id="goal-panel-records-${goalId}" class="goal-workspace-panel" role="tabpanel" aria-labelledby="goal-tab-records-${goalId}" data-goal-panel="records" hidden>
-        ${renderGoalTechnicalDetails(item, view)}
+        <div data-goal-records-content data-loaded="false"><p class="empty-row" role="status">${L("正在载入完整记录…")}</p></div>
       </div>
     </div>
     ${quickRecordAction ? renderQuickRecordDialog(item, view) : ""}
@@ -3616,6 +3616,19 @@ export function renderGoalDocumentFragment(
     ? renderTrashGoalDocument(item, true)
     : renderGoalDocument(item, view, true);
   return prefixLocalLinks(html, view.route_prefix);
+}
+
+/** Render the heavy, read-only record ledger only after its Goal tab is opened. */
+export function renderGoalRecordsFragment(
+  view: GoalBoardWebView,
+  goalId: string,
+  collection: GoalDocumentCollection = "current",
+): string | null {
+  if (collection === "trash") return null;
+  const items = collection === "archive" ? view.archived_goals : view.goals;
+  const item = items.find((candidate) => candidate.goal.goal_id === goalId);
+  if (!item) return null;
+  return prefixLocalLinks(renderGoalTechnicalDetails(item, view), view.route_prefix);
 }
 
 function renderGoalTrashDialog(): string {
@@ -5990,6 +6003,10 @@ const CLIENT_SCRIPT = `
     const visibleGoals = (source = state) => trashView ? source.trashed_goals : archiveView ? source.archived_goals : source.goals;
     const storageKey = "goalboard-ui:" + (state.project?.project_id || state.snapshot.board.board_id);
     let selected = decisionView ? "" : document.querySelector("[data-goal-view]:not([hidden])")?.dataset.goalView || (collectionView ? visibleGoals()[0]?.goal.goal_id : state.active_goal_id || visibleGoals()[0]?.goal.goal_id) || "";
+    if (!decisionView) {
+      const initialHistoryState = history.state && typeof history.state === "object" ? history.state : {};
+      history.replaceState({ ...initialHistoryState, goalId: selected }, "", location.href);
+    }
     let trashIntent = null;
     let toastTimer;
     let syncing = false;
@@ -6618,6 +6635,41 @@ const CLIENT_SCRIPT = `
       return target?.closest?.("[data-goal-factor-panel]")?.dataset.goalFactorPanel || "";
     };
 
+    const loadGoalRecords = async (article) => {
+      const container = article?.querySelector("[data-goal-records-content]");
+      if (!container || container.dataset.loaded === "true" || container.dataset.loading === "true") return;
+      const goalId = article.dataset.goalView;
+      if (!goalId) return;
+      container.dataset.loading = "true";
+      container.setAttribute("aria-busy", "true");
+      try {
+        const response = await fetch(
+          route("/api/goals/" + encodeURIComponent(goalId) + "/records?view=" + documentCollection),
+          { cache: "no-store" },
+        );
+        if (!response.ok) throw new Error(L("无法读取这条 Goal 的完整记录"));
+        const template = document.createElement("template");
+        template.innerHTML = (await response.text()).trim();
+        const records = template.content.querySelector('[data-goal-section="technical"]');
+        if (!records) throw new Error(L("Goal 记录响应不完整"));
+        if (!article.isConnected || article.dataset.goalView !== goalId) return;
+        container.replaceChildren(records);
+        container.dataset.loaded = "true";
+      } catch (error) {
+        if (!article.isConnected || article.dataset.goalView !== goalId) return;
+        const message = error instanceof Error ? error.message : L("无法载入完整记录");
+        const errorRow = document.createElement("p");
+        errorRow.className = "empty-row";
+        errorRow.setAttribute("role", "alert");
+        errorRow.textContent = message;
+        container.replaceChildren(errorRow);
+        showToast(message, true);
+      } finally {
+        container.dataset.loading = "false";
+        container.removeAttribute("aria-busy");
+      }
+    };
+
     const setGoalPanel = (panelName, persist = true, updateHash = false, resetScroll = false) => {
       const article = documentPane.querySelector("[data-goal-view]");
       if (!article) return false;
@@ -6633,6 +6685,7 @@ const CLIENT_SCRIPT = `
       article.querySelectorAll("[data-goal-panel]").forEach((candidate) => {
         candidate.hidden = candidate !== activePanel;
       });
+      if (panel === "records") void loadGoalRecords(article);
       if (updateHash) history.replaceState(history.state, "", "#" + activePanel.id);
       if (resetScroll) article.querySelector(".goal-workspace-nav")?.scrollIntoView({ block: "start" });
       if (persist) queueSave();
@@ -8367,11 +8420,17 @@ const CLIENT_SCRIPT = `
       }
     });
 
-    addEventListener("popstate", () => {
-      const match = localPathname().match(
+    addEventListener("popstate", (event) => {
+      const pathname = localPathname();
+      const match = pathname.match(
         trashView ? /^\\/trash\\/goals\\/(.+)$/ : archiveView ? /^\\/archive\\/goals\\/(.+)$/ : /^\\/goals\\/(.+)$/,
       );
-      if (match) void selectGoal(decodeURIComponent(match[1]), false);
+      const collectionRoot = trashView ? "/trash" : archiveView ? "/archive" : "/";
+      const rootGoalId = pathname === collectionRoot
+        ? String(event.state?.goalId || state.active_goal_id || visibleGoals()[0]?.goal.goal_id || "")
+        : "";
+      const goalId = match ? decodeURIComponent(match[1]) : rootGoalId;
+      if (goalId) void selectGoal(goalId, false);
     });
     addEventListener("hashchange", () => {
       const targetId = decodeURIComponent(location.hash.slice(1));

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -39,6 +39,7 @@ import {
 } from "../install/web-service.js";
 import {
   renderGoalDocumentFragment,
+  renderGoalRecordsFragment,
   renderGoalBoardWeb,
   renderGoalBoardProjectIndex,
   renderGoalBoardProjectSettings,
@@ -118,21 +119,11 @@ type WebViewOptions = Pick<
 
 interface GoalBoardWebViewCacheEntry {
   cursor: number;
-  databaseVersion: string;
   optionsFingerprint: string;
   view: GoalBoardWebView;
 }
 
 type GoalBoardWebViewCache = Map<string, GoalBoardWebViewCacheEntry>;
-
-function sqliteMainDatabaseVersion(databasePath: string): string {
-  try {
-    const stat = fs.statSync(databasePath, { bigint: true });
-    return `${stat.size}:${stat.mtimeNs}`;
-  } catch {
-    return "missing";
-  }
-}
 
 type ResolvedWebRequest =
   | { kind: "catalog_index"; projects: WebProjectNavigation[] }
@@ -378,7 +369,7 @@ export function buildGoalBoardWebView(
     goal_ids: riskGoalIds.get(risk.risk_id) ?? [],
   }));
   const workStates = new Map(
-    coordinator.getGoalWorkStates({ board_id: options.boardId }).map((state) => [state.goal_id, state]),
+    coordinator.getGoalWorkStates({ board_id: options.boardId, snapshot }).map((state) => [state.goal_id, state]),
   );
   const allGoals = snapshot.goals.map((goal) => {
     const workState = workStates.get(goal.goal_id);
@@ -566,7 +557,6 @@ export function cachedGoalBoardWebView(
   options: WebViewOptions,
 ): GoalBoardWebView {
   const cursor = store.eventCursor(options.boardId);
-  const databaseVersion = sqliteMainDatabaseVersion(options.databasePath);
   const optionsFingerprint = JSON.stringify({
     board_id: options.boardId,
     demo: Boolean(options.demo),
@@ -578,20 +568,11 @@ export function cachedGoalBoardWebView(
   const cached = cache.get(options.databasePath);
   if (
     cached?.cursor === cursor &&
-    cached.databaseVersion === databaseVersion &&
     cached.optionsFingerprint === optionsFingerprint
   ) return cached.view;
   const view = buildGoalBoardWebView(store, coordinator, options);
-  cache.set(options.databasePath, { cursor, databaseVersion, optionsFingerprint, view });
+  cache.set(options.databasePath, { cursor, optionsFingerprint, view });
   return view;
-}
-
-function alignCachedMainDatabaseVersion(
-  cache: GoalBoardWebViewCache,
-  databasePath: string,
-): void {
-  const cached = cache.get(databasePath);
-  if (cached) cached.databaseVersion = sqliteMainDatabaseVersion(databasePath);
 }
 
 function sendJson(response: ServerResponse, status: number, value: unknown): void {
@@ -1647,12 +1628,8 @@ async function handleGoalBoardWebRequest(
         () => new Date(),
         readPersonalPlanningMethodPacks(serverOptions.homeDirectory),
       );
-      let webViewWasRead = false;
-      const readWebView = (): GoalBoardWebView => {
-        const view = cachedGoalBoardWebView(webViewCache, store, coordinator, options);
-        webViewWasRead = true;
-        return view;
-      };
+      const readWebView = (): GoalBoardWebView =>
+        cachedGoalBoardWebView(webViewCache, store, coordinator, options);
       try {
         if (request.method === "GET" && url.pathname === "/settings/rules") {
           response.writeHead(200, {
@@ -1824,13 +1801,13 @@ async function handleGoalBoardWebRequest(
           );
           if (handled) return;
         }
-        const goalDocumentMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/document$/);
-        if (request.method === "GET" && goalDocumentMatch) {
+        const goalFragmentMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/(document|records)$/);
+        if (request.method === "GET" && goalFragmentMatch) {
           let goalId: string;
           try {
-            goalId = decodeURIComponent(goalDocumentMatch[1]);
+            goalId = decodeURIComponent(goalFragmentMatch[1]);
           } catch {
-            sendJson(response, 404, { error: "Goal 正文不存在" });
+            sendJson(response, 404, { error: "Goal 内容不存在" });
             return;
           }
           const collection = url.searchParams.get("view") ?? "current";
@@ -1839,7 +1816,9 @@ async function handleGoalBoardWebRequest(
             return;
           }
           const view = readWebView();
-          const fragment = renderGoalDocumentFragment(view, goalId, collection);
+          const fragment = goalFragmentMatch[2] === "records"
+            ? renderGoalRecordsFragment(view, goalId, collection)
+            : renderGoalDocumentFragment(view, goalId, collection);
           if (!fragment) {
             sendJson(response, 404, { error: `找不到这个 Goal: ${goalId}` });
             return;
@@ -2895,7 +2874,6 @@ async function handleGoalBoardWebRequest(
         sendJson(response, 404, { error: L("页面或接口不存在") });
       } finally {
         store.close();
-        if (webViewWasRead) alignCachedMainDatabaseVersion(webViewCache, options.databasePath);
       }
 }
 

--- a/tests/desktop-tui.test.ts
+++ b/tests/desktop-tui.test.ts
@@ -615,6 +615,19 @@ test("compound parent terminals become read-only and direct execution APIs requi
       completionStore.db
         .prepare("UPDATE goals SET fulfillment_state = 'satisfied' WHERE goal_id IN (?, ?)")
         .run("TUI-CHILD", "TUI-PARENT");
+      // This test-only fixture mutation bypasses the coordinator, so publish a
+      // matching cursor event just as every supported product write does.
+      completionStore.appendEvent({
+        eventId: "desktop-tui-compound-completed",
+        boardId: fixture.project.board_id,
+        actorId: "test-user",
+        type: "test.fixture.updated",
+        objectType: "goal",
+        objectId: "TUI-PARENT",
+        reason: "测试复合 Goal 完成后的只读终端",
+        payload: { child_goal_id: "TUI-CHILD" },
+        at: new Date().toISOString(),
+      });
     } finally {
       completionStore.close();
     }

--- a/tests/v1.test.ts
+++ b/tests/v1.test.ts
@@ -413,8 +413,9 @@ test("batch Goal work states match canonical single-Goal reads", () => {
       { actor_id: "user-1", idempotency_key: "batch-state-draft" },
     );
 
+    const snapshot = store.snapshot("board-1");
     const batch = new Map(
-      coordinator.getGoalWorkStates({ board_id: "board-1" }).map((state) => [state.goal_id, state]),
+      coordinator.getGoalWorkStates({ board_id: "board-1", snapshot }).map((state) => [state.goal_id, state]),
     );
     for (const goal of store.listGoals("board-1")) {
       assert.deepEqual(

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -18,6 +18,7 @@ import {
   activeOutgoingDependsOn,
   displayedPassedCriterionIds,
   firstBlockedDescendant,
+  renderGoalRecordsFragment,
   renderGoalBoardWeb,
   sortGoalTreeItems,
   unsatisfiedOutgoingDependencies,
@@ -126,7 +127,7 @@ function webFixture() {
   return { databasePath };
 }
 
-test("Web View cache follows Board events and main DB changes instead of SQLite WAL lifecycle", () => {
+test("Web View cache follows canonical Board events instead of SQLite file lifecycle", () => {
   const { databasePath } = webFixture();
   const cache = new Map() as Parameters<typeof cachedGoalBoardWebView>[0];
   const options = { databasePath, boardId: DEMO_BOARD_ID, demo: true };
@@ -164,18 +165,6 @@ test("Web View cache follows Board events and main DB changes instead of SQLite 
     assert.notStrictEqual(changed, first);
     assert.ok(changed.goals.some((item) => item.goal.goal_id === "CACHE-EVENT"));
 
-    const cursorBeforeDirectWrite = reopenedStore.eventCursor(DEMO_BOARD_ID);
-    reopenedStore.db
-      .prepare("UPDATE goals SET title = ? WHERE goal_id = ?")
-      .run("没有事件的存量写入", "CACHE-EVENT");
-    reopenedStore.db.pragma("wal_checkpoint(TRUNCATE)");
-    assert.equal(reopenedStore.eventCursor(DEMO_BOARD_ID), cursorBeforeDirectWrite);
-    const directlyChanged = cachedGoalBoardWebView(cache, reopenedStore, coordinator, options);
-    assert.notStrictEqual(directlyChanged, changed);
-    assert.equal(
-      directlyChanged.goals.find((item) => item.goal.goal_id === "CACHE-EVENT")?.goal.title,
-      "没有事件的存量写入",
-    );
   } finally {
     reopenedStore.close();
   }
@@ -616,6 +605,10 @@ test("Web view derives understandable Goal states from canonical SQLite facts", 
   assert.match(historyRootHtml, /处理 \d+ 项决定/);
   const html = renderGoalBoardWeb(view);
   const coreHtml = renderGoalBoardWeb(view, "CORE");
+  const recordsFragment = renderGoalRecordsFragment(view, "V1");
+  const coreRecordsFragment = renderGoalRecordsFragment(view, "CORE");
+  assert.ok(recordsFragment);
+  assert.ok(coreRecordsFragment);
   const decisionHtml = renderGoalBoardWeb(view, undefined, false, true);
   assert.ok(html.startsWith("<!--\nTHESIS:"));
   assert.equal((html.match(/data-goal-view=/g) ?? []).length, 1);
@@ -664,25 +657,27 @@ test("Web view derives understandable Goal states from canonical SQLite facts", 
   assert.match(html, /data-quick-record-type="impact"/);
   assert.match(html, /data-quick-record-type="relation"/);
   assert.equal((html.match(/class="goal-primary-action"/g) ?? []).length, 1);
-  assert.match(html, /<section class="goal-technical"[^>]*>/);
-  assert.doesNotMatch(html, /查看执行细节|goal-execution-details/);
-  assert.match(html, /领取、推进、完成依据和检查记录/);
+  assert.doesNotMatch(html, /<section class="goal-technical"[^>]*>/);
+  assert.match(html, /data-goal-records-content data-loaded="false"/);
+  assert.match(recordsFragment, /<section class="goal-technical"[^>]*>/);
+  assert.doesNotMatch(recordsFragment, /查看执行细节|goal-execution-details/);
+  assert.match(recordsFragment, /领取、推进、完成依据和检查记录/);
   assert.match(html, /为什么现在做/);
-  assert.match(html, /目标标识、负责人、时间、状态和完整工作边界/);
-  assert.match(html, /当前状态/);
-  assert.match(html, /class="contract-list"/);
-  assert.doesNotMatch(html, /class="contract-grid"/);
-  assert.match(html, /包含什么/);
-  assert.match(html, /明确不做/);
-  assert.match(html, /必须遵守/);
-  assert.match(html, /需要的输入/);
-  assert.match(html, /承诺的输出/);
+  assert.match(recordsFragment, /目标标识、负责人、时间、状态和完整工作边界/);
+  assert.match(recordsFragment, /当前状态/);
+  assert.match(recordsFragment, /class="contract-list"/);
+  assert.doesNotMatch(recordsFragment, /class="contract-grid"/);
+  assert.match(recordsFragment, /包含什么/);
+  assert.match(recordsFragment, /明确不做/);
+  assert.match(recordsFragment, /必须遵守/);
+  assert.match(recordsFragment, /需要的输入/);
+  assert.match(recordsFragment, /承诺的输出/);
   assert.match(html, /Goal 关系/);
   assert.match(html, /上游/);
   assert.match(html, /下游/);
-  assert.match(html, /Claim 历史/);
-  assert.match(html, /Run 历史/);
-  assert.match(html, /风险与影响/);
+  assert.match(recordsFragment, /Claim 历史/);
+  assert.match(recordsFragment, /Run 历史/);
+  assert.match(recordsFragment, /风险与影响/);
   assert.match(html, /工作规则/);
   assert.match(html, /项目默认规则/);
   assert.match(html, /为当前 Goal 增加要求/);
@@ -692,15 +687,11 @@ test("Web view derives understandable Goal states from canonical SQLite facts", 
   assert.match(html, /data-live-form="policy-goal-/);
   assert.match(html, /name="required_capabilities"/);
   assert.match(html, /name="max_lease_seconds"/);
-  const recordsStart = html.indexOf('data-goal-panel="records"');
-  const quickDialogStart = html.indexOf('data-quick-record-dialog', recordsStart);
-  const recordsHtml = html.slice(recordsStart, quickDialogStart);
-  assert.doesNotMatch(recordsHtml, /data-(?:relation|risk|impact|evidence|policy)[a-z-]*-form/);
-  assert.match(recordsHtml, /基础信息/);
-  assert.match(recordsHtml, /执行与检查/);
-  assert.match(recordsHtml, /变更历史/);
-  assert.match(recordsHtml, /关联与规则记录/);
-  assert.match(html, /事件历史/);
+  assert.doesNotMatch(recordsFragment, /data-(?:relation|risk|impact|evidence|policy)[a-z-]*-form/);
+  assert.match(recordsFragment, /基础信息/);
+  assert.match(recordsFragment, /执行与检查/);
+  assert.match(recordsFragment, /变更历史/);
+  assert.match(recordsFragment, /关联与规则记录/);
   assert.match(html, /待决定/);
   assert.match(html, /打开不会自动发送或领取/);
   assert.match(html, /示例数据/);
@@ -711,10 +702,10 @@ test("Web view derives understandable Goal states from canonical SQLite facts", 
   assert.match(coreHtml, /验证 corrects 关系的完整呈现/);
   assert.match(coreHtml, /字段过多导致信息过载/);
   assert.match(coreHtml, /fixture-snapshot/);
-  assert.match(coreHtml, /REQ-WEB-COVERAGE/);
-  assert.match(coreHtml, /sha256:web-fixture/);
-  assert.match(coreHtml, /href="https:\/\/example.com\/goalboard-contract"/);
-  assert.match(coreHtml, /data-copy-value/);
+  assert.match(coreRecordsFragment, /REQ-WEB-COVERAGE/);
+  assert.match(coreRecordsFragment, /sha256:web-fixture/);
+  assert.match(coreRecordsFragment, /href="https:\/\/example.com\/goalboard-contract"/);
+  assert.match(coreRecordsFragment, /data-copy-value/);
   assert.match(html, /data-select-goal/);
   assert.match(html, /class="tree-chrome"/);
   assert.match(html, /class="tree-search"/);
@@ -798,7 +789,7 @@ test("Web view derives understandable Goal states from canonical SQLite facts", 
   assert.match(html, /\["ArrowLeft", "ArrowRight", "Home", "End"\]/);
   assert.match(html, /父 Goal 如何完成/);
   assert.match(html, /href="\/goals\/PLATFORM"/);
-  assert.match(html, /id="execution-V1"/);
+  assert.match(recordsFragment, /id="execution-V1"/);
   assert.match(html, /id="acceptance-V1"/);
   assert.match(html, /data-collapse-all aria-label="折叠全部"/);
   assert.match(html, /class="tree-dep is-waiting"/);
@@ -838,8 +829,8 @@ test("Web view derives understandable Goal states from canonical SQLite facts", 
   assert.match(html, /target\.closest\("button\[data-navigator-view\]"\)/);
   assert.doesNotMatch(html, /api\/goals\/[^"']+\/graph/);
   assert.match(html, /<span class="tree-dep-copy"><strong>让不同 AI 对话看到同一项目进度<\/strong>/);
-  assert.match(html, /class="scope-gaps"/);
-  assert.match(html, /还有 \d+ 项未写|范围、输入与输出尚未填写/);
+  assert.match(recordsFragment, /class="scope-gaps"/);
+  assert.match(recordsFragment, /还有 \d+ 项未写|范围、输入与输出尚未填写/);
   const webGoal = view.goals.find((item) => item.goal.goal_id === "WEB");
   const v1Goal = view.goals.find((item) => item.goal.goal_id === "V1");
   const interfacesGoal = view.goals.find((item) => item.goal.goal_id === "INTERFACES");
@@ -3953,8 +3944,11 @@ test("Web maintains a structured Draft Contract and initial Risk and Impact with
     assert.ok(board.snapshot.impacts.some((impact) => impact.goal_id === "EDIT-ME" && impact.surface === "src/web" && impact.state === "confirmed"));
 
     const updatedPage = await (await webFetch(`${origin}/goals/EDIT-ME`)).text();
-    assert.match(updatedPage, /目标：100%/);
-    assert.match(updatedPage, /证据：test、inspection/);
+    const updatedRecords = await (
+      await webFetch(`${origin}/api/goals/EDIT-ME/records?view=current`)
+    ).text();
+    assert.match(updatedRecords, /目标：100%/);
+    assert.match(updatedRecords, /证据：test、inspection/);
     assert.match(updatedPage, /子 Goal 边界仍可能重叠/);
     assert.match(updatedPage, /contract:\/\/EDIT-ME/);
 
@@ -4494,13 +4488,19 @@ test("Web edits project and Goal Policy and submits a user-only Human Review", a
     assert.match(page, /const paneHeader = documentPane\.querySelector\(":scope > \.desktop-pane-header"\)/);
     assert.match(page, /documentPane\.replaceChildren\(\.\.\.\(paneHeader \? \[paneHeader, nextView\] : \[nextView\]\)\)/);
     assert.match(page, /\/api\/goals\/" \+ encodeURIComponent\(goalId\) \+ "\/document\?view=/);
+    assert.match(page, /\/api\/goals\/" \+ encodeURIComponent\(goalId\) \+ "\/records\?view=/);
+    assert.match(page, /history\.replaceState\(\{ \.\.\.initialHistoryState, goalId: selected \}/);
+    assert.match(page, /event\.state\?\.goalId \|\| state\.active_goal_id/);
     assert.doesNotMatch(page, /documentPane\.innerHTML = nextDocument\.innerHTML/);
     assert.match(page, /policy-mode-options, \.policy-control--split, \.policy-toggle-list, \.policy-review-counts \{ grid-template-columns: 1fr; \}/);
     assert.match(page, /value="browser"/);
     assert.match(page, /href="\/decisions#decision-goal-POLICY-WEB"/);
     assert.match(page, /处理 \d+ 项决定/);
     assert.doesNotMatch(page, /<form class="human-review-form"/);
-    assert.match(page, new RegExp(evidence.evidence_id));
+    const policyRecords = await (
+      await webFetch(`${origin}/api/goals/POLICY-WEB/records?view=current`)
+    ).text();
+    assert.match(policyRecords, new RegExp(evidence.evidence_id));
     assert.match(page, /data-decisions-link[^>]*aria-label="待决定 [0-9]+"/);
     assert.match(page, /class="project-decisions/);
     assert.match(page, /class="tree-chrome"/);
@@ -4753,7 +4753,12 @@ test("Web records manual Evidence, safely opens project references, and exposes 
     const beforeSubmit = await (await webFetch(`${origin}/goals/EVIDENCE-WEB`)).text();
     assert.match(beforeSubmit, /data-evidence-form/);
     assert.match(beforeSubmit, /保存完成依据/);
-    assert.match(beforeSubmit, /完整事件账本/);
+    assert.match(beforeSubmit, /data-goal-records-content data-loaded="false"/);
+    assert.doesNotMatch(beforeSubmit, /完整事件账本/);
+    const recordsBeforeSubmit = await (
+      await webFetch(`${origin}/api/goals/EVIDENCE-WEB/records?view=current`)
+    ).text();
+    assert.match(recordsBeforeSubmit, /完整事件账本/);
 
     const missingCriterion = await webFetch(`${origin}/api/goals/EVIDENCE-WEB/evidence`, {
       method: "POST",
@@ -4810,14 +4815,18 @@ test("Web records manual Evidence, safely opens project references, and exposes 
     }
 
     const goalPage = await (await webFetch(`${origin}/goals/EVIDENCE-WEB`)).text();
-    assert.match(goalPage, new RegExp(submittedResult.evidence.evidence_id));
-    assert.match(goalPage, /href="\/api\/project-references\/notes%2Fevidence\.txt"/);
-    assert.match(goalPage, /data-project-reference/);
-    assert.match(goalPage, /href="https:\/\/example\.com\/manual-evidence"/);
-    assert.match(goalPage, /evidence\.submitted/);
-    assert.match(goalPage, /risk\.created/);
-    assert.match(goalPage, /relation\.added/);
-    assert.match(goalPage, /policy\.added/);
+    assert.doesNotMatch(goalPage, /完整事件账本/);
+    const goalRecords = await (
+      await webFetch(`${origin}/api/goals/EVIDENCE-WEB/records?view=current`)
+    ).text();
+    assert.match(goalRecords, new RegExp(submittedResult.evidence.evidence_id));
+    assert.match(goalRecords, /href="\/api\/project-references\/notes%2Fevidence\.txt"/);
+    assert.match(goalRecords, /data-project-reference/);
+    assert.match(goalRecords, /href="https:\/\/example\.com\/manual-evidence"/);
+    assert.match(goalRecords, /evidence\.submitted/);
+    assert.match(goalRecords, /risk\.created/);
+    assert.match(goalRecords, /relation\.added/);
+    assert.match(goalRecords, /policy\.added/);
 
     const opened = await webFetch(`${origin}/api/project-references/${encodeURIComponent("notes/evidence.txt")}`);
     assert.equal(opened.status, 200, await opened.clone().text());


### PR DESCRIPTION
## Summary
- lazy-load complete Goal records while preserving the full ledger
- keep Goal selection consistent across browser history
- reuse one Board snapshot and canonical event-cursor cache invalidation

## Verification
- pnpm typecheck
- targeted V1/Web/E2E: 95/95
- pnpm test: 209/209
- real Footballnia browser navigation and record loading regression