### PR TITLE
feat(runtime): suggest safe parallel Goal execution

### DIFF
--- a/docs/goalboard-optimization-handoff-2026-08-28.md
+++ b/docs/goalboard-optimization-handoff-2026-08-28.md
@@ -2,9 +2,9 @@
 
 ## 交接结论
 
-本轮不再使用 GoalBoard 推进 GoalBoard 自身优化。已经满足的 7 个 Goal 已从原脏工作树中拆成 7 个顺序提交，位于分支 `codex/split-completed-goal-fixes`，共同基线为 `63e1246`。后续应以 Git 提交、代码评审和测试结果推进，不再把 GoalBoard 账本状态当作执行入口。
+本轮不再使用 GoalBoard 推进 GoalBoard 自身优化。已经满足的 7 个 Goal 已从原脏工作树中拆成 7 个顺序提交，并已随集成提交 `140d25e` 快进到远端 `main`。最后一条“安全并行 Runtime 建议”Candidate 的代码修复位于分支 `codex/proactive-safe-parallel-runtime-choice`，与本文更新放在同一个独立提交中。后续仍以 Git 提交、代码评审和测试结果推进，不再把 GoalBoard 账本状态当作执行入口。
 
-本文生成时还没有推送、合并、安装或发布；也没有清理原工作树中尚未完成的改动。后续 landing 状态以 Git 远端和 PR 记录为准。
+本轮没有安装或发布，也没有清理原工作树中尚未完成的改动。最后一条 Candidate 修复是否已推送或合并，以 Git 远端和 PR 记录为准。
 
 ## 已修好的 Goal 与对应提交
 
@@ -30,7 +30,7 @@
 | --- | --- | --- | --- |
 | `candidate-a7bfb094-78e2-4f0a-83e7-2a714c2e5e0e` | `candidate-existing-promotion-regression-20260828` | 恢复现有 Candidate 的统一提案晋升能力 | 对应能力已经由 `4b123e8` 修复，但原 Candidate 仍是 pending；后续应人工决定如何关闭或对账，不能用代码完成替代账本决定。 |
 | `candidate-a61d322a-6274-4101-9021-e3f3d2af0d7d` | `review-needs-changes-routing-regression-20260828` | 修复 0.1.2 中 needs_changes 返工路由回退 | 对应能力已经由 `6435a74` 修复；原晋升提案仍 pending，并曾出现 `candidate_exists` 冲突。后续应先核对正式 Goal 与 Candidate 的唯一对应关系，再由用户处理账本状态。 |
-| `candidate-2a9a60f8-db28-4806-bc58-1258611d131e` | `proactive-safe-parallel-runtime-choice` | 在多个 Goal 可安全并行时主动提出执行与 Runtime 分配方案 | 尚未晋升，且与本轮 7 个修复提交无直接完成关系。保持候选，等真实并行场景和责任边界明确后再决定。 |
+| `candidate-2a9a60f8-db28-4806-bc58-1258611d131e` | `proactive-safe-parallel-runtime-choice` | 在多个 Goal 可安全并行时主动提出执行与 Runtime 分配方案 | 对应能力已由分支 `codex/proactive-safe-parallel-runtime-choice` 的独立修复覆盖：Available 只在 executor Goal 都有 confirmed Impact 且两两兼容时返回只读分配建议；它不会自动启动 Runtime 或 Claim。原 Candidate 仍是 pending，后续账本决定仍归用户。 |
 
 ## 仍留在工作树、未作为完成项提交的改动
 
@@ -55,12 +55,13 @@
 3. 在干净集成结果上运行完整 TypeScript、v1、MCP、Web、安装与端到端测试；定向测试结果不能替代整仓回归。
 4. 对真实安装产物补做升级恢复、Web 启动与深链打开的产品实操；主观体验和真人确认项标记为 `UNVERIFIED`，直到用户本人认可。
 5. 再从“仍留在工作树”的工作簇中一次只选一个最小闭环，单独审查、实现和提交。
-6. 3 条 pending Candidate 属于账本治理，不属于 Git 合并动作。除非用户以后明确要求，否则不要再通过 GoalBoard 推进或代替用户作 Candidate 决定。
+6. 3 条 pending Candidate 的对应代码范围均已有修复，但账本状态仍属治理问题，不属于 Git 合并动作。除非用户以后明确要求，否则不要再通过 GoalBoard 推进或代替用户作 Candidate 决定。
 
 ## 拆分完成时的 Git 边界
 
 - 工作树：`/Users/oreal/.codex/worktrees/eea6/goalboard`
 - 分支：`codex/split-completed-goal-fixes`
 - 拆分基线：`63e1246`
-- 修复提交范围：`1feac8d..6435a74`（共 7 个提交）
-- 本文生成时未执行：push、merge、rebase、安装、发布、剩余改动清理
+- 已合入 `main` 的修复提交范围：`1feac8d..6435a74`（共 7 个提交），集成边界为 `140d25e`
+- 最后一条 Candidate 修复分支：`codex/proactive-safe-parallel-runtime-choice`
+- 本轮未执行：安装、发布、剩余改动清理或 GoalBoard 账本写入

--- a/skills/goal-advance/references/execution.md
+++ b/skills/goal-advance/references/execution.md
@@ -13,6 +13,8 @@ For an ordinary “继续推进” or “领一件能做的” request:
 
 GoalBoard does not dispatch one mandatory next task. The Runtime chooses among eligible work and explains which Goal it chose, why it fits now, and what state changed. Do not make the user choose unless there is a genuine intent or product tradeoff.
 
+When Available returns a non-null `parallel_suggestion`, proactively explain the concrete value of splitting those assignments across the returned abstract Runtime slots and ask whether the user wants that split. The suggestion is advisory only: do not start another Runtime, select or Claim any assignment, or imply that GoalBoard has dispatched work. After the user agrees, every participating Runtime must re-read Available with its real capabilities and individually call `goalboard_v1_select_goal` for its assigned Goal. If the suggestion is null, an Impact is unconfirmed, or the fresh read shows a conflict, do not claim that parallel execution is safe.
+
 For a named Goal absent from Available, call `goalboard_v1_explain` and report its actual dependency, Risk, capability, review, validity, or active-Claim blocker. Never bypass the blocker with legacy `ready → claim → run_start`; the normal path is `available → select_goal`.
 
 If `GOALBOARD_GOAL_ID` is set, prefer that Desktop-opened Goal for “继续推进.” Opening the panel itself is not permission to select it.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -268,7 +268,7 @@ const V1_TOOLS: McpToolDefinition[] = [
   {
     name: "goalboard_v1_available",
     description:
-      "返回当前 Runtime 可推进的统一 Available 集合，覆盖澄清、执行、复核和重新验证；需要用户确认是否收口的父 Goal 会明确标记并排在普通工作前，Runtime 仍自主选择，不派发唯一下一份。",
+      "返回当前 Runtime 可推进的统一 Available 集合，覆盖澄清、执行、复核和重新验证；需要用户确认是否收口的父 Goal 会明确标记并排在普通工作前。多个 executor Goal 具有已确认且互不冲突的 Impact 时，会附带 advisory_only 的 parallel_suggestion 供 Runtime 主动提议分工，但不会启动 Runtime、领取 Goal 或派发唯一下一份。",
     inputSchema: {
       type: "object",
       properties: {

--- a/src/v1/coordinator.ts
+++ b/src/v1/coordinator.ts
@@ -46,6 +46,7 @@ import {
   type GoalWorkStateView,
   type ImpactAccess,
   type ImpactBindingRecord,
+  type ParallelExecutionSuggestion,
   type ReadyGoal,
   type RevalidationDecision,
   type ReviewRecord,
@@ -135,6 +136,7 @@ export interface AvailableQuery {
 export interface AvailableQueryResult {
   observed_event_cursor: number;
   available: AvailableGoal[];
+  parallel_suggestion: ParallelExecutionSuggestion | null;
 }
 
 export interface GoalTreeProposalListQuery {
@@ -2299,7 +2301,11 @@ export class GoalBoardCoordinator {
         left.goal.goal_id.localeCompare(right.goal.goal_id) ||
         left.role.localeCompare(right.role),
     );
-    return { observed_event_cursor: snapshot.cursor, available };
+    return {
+      observed_event_cursor: snapshot.cursor,
+      available,
+      parallel_suggestion: this.parallelExecutionSuggestion(available),
+    };
   }
 
   /** Read the canonical work state that Web, MCP and CLI should present. */
@@ -9122,6 +9128,58 @@ export class GoalBoardCoordinator {
     if (existingAccess === "read" && requested.access === "write") return Boolean(existingSnapshot);
     if (existingAccess === "write" && requested.access === "read") return Boolean(requested.input_snapshot);
     return false;
+  }
+
+  private parallelExecutionSuggestion(
+    available: AvailableGoal[],
+  ): ParallelExecutionSuggestion | null {
+    const selected: Array<{ item: AvailableGoal; surfaces: ImpactBindingRecord[] }> = [];
+    for (const item of available) {
+      if (item.role !== "executor" || item.next_action !== "execute") continue;
+      const surfaces = item.relevant_surfaces.filter((impact) => impact.state === "confirmed");
+      if (surfaces.length === 0) continue;
+      if (
+        selected.some(
+          (existing) => !this.impactSetsAllowParallel(existing.surfaces, surfaces),
+        )
+      ) {
+        continue;
+      }
+      selected.push({ item, surfaces });
+    }
+    if (selected.length < 2) return null;
+    return {
+      kind: "safe_parallel_execution",
+      advisory_only: true,
+      assignments: selected.map(({ item }, index) => ({
+        runtime_slot: index === 0 ? "current_runtime" : `additional_runtime_${index}`,
+        goal_id: item.goal.goal_id,
+        title: item.goal.title,
+        role: "executor",
+        required_capabilities: item.resolved_policy.required_capabilities,
+      })),
+    };
+  }
+
+  private impactSetsAllowParallel(
+    existing: ImpactBindingRecord[],
+    requested: ImpactBindingRecord[],
+  ): boolean {
+    for (const requestedImpact of requested) {
+      for (const existingImpact of existing) {
+        if (existingImpact.surface !== requestedImpact.surface) continue;
+        if (
+          !this.isImpactPairSafe(
+            existingImpact.access,
+            existingImpact.input_snapshot,
+            requestedImpact,
+          )
+        ) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   private goalImpacts(

--- a/src/v1/types.ts
+++ b/src/v1/types.ts
@@ -694,6 +694,20 @@ export interface AvailableGoal extends ReadyGoal {
   };
 }
 
+export interface ParallelRuntimeAssignment {
+  runtime_slot: "current_runtime" | `additional_runtime_${number}`;
+  goal_id: string;
+  title: string;
+  role: "executor";
+  required_capabilities: string[];
+}
+
+export interface ParallelExecutionSuggestion {
+  kind: "safe_parallel_execution";
+  advisory_only: true;
+  assignments: ParallelRuntimeAssignment[];
+}
+
 export interface BoardSnapshot {
   board: {
     board_id: string;

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -521,7 +521,7 @@ describe("mcp server", () => {
     }
   });
 
-  it("serves one filtered V1 Goal Contract with a stable Web URL", async () => {
+  it("serves a stable Goal Contract and the Available safe-parallel suggestion", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "goalboard-mcp-v1-"));
     const databasePath = path.join(directory, "goalboard.db");
     const management = new GoalBoardServer("management");
@@ -563,6 +563,7 @@ describe("mcp server", () => {
           business_logic: "Runtime 读取一个 Goal 的全部工作约束，再决定是否认领。",
           definition_state: "accepted",
           decomposition_state: "closed_leaf",
+          priority: 20,
           acceptance_criteria: [
             {
               criterion_id: "mcp-contract",
@@ -592,6 +593,52 @@ describe("mcp server", () => {
       assert.equal(contract.goal_url, "https://goalboard.example/goals/goal%2Fwith%20space");
       assert.deepEqual(contract.relations, []);
 
+      const secondGoal = await call(management, "goalboard_v1_create_goal", {
+        database_path: databasePath,
+        board_id: "mcp-board",
+        actor_id: "user-1",
+        idempotency_key: "create-mcp-parallel-goal",
+        goal: {
+          goal_id: "parallel-guide",
+          title: "更新并行执行指南",
+          outcome: "Runtime 获得可独立检查的使用说明",
+          why: "验证 MCP 能把安全并行建议完整返回给 Runtime。",
+          business_logic: "这条 Goal 只更新独立文档，不修改另一个 Goal 的代码范围。",
+          definition_state: "accepted",
+          decomposition_state: "closed_leaf",
+          priority: 10,
+          acceptance_criteria: [
+            {
+              criterion_id: "parallel-guide-contract",
+              statement: "并行执行指南可检查",
+              decision_method: "inspection",
+              pass_condition: "指南说明 Runtime 分配边界",
+            },
+          ],
+        },
+      });
+      assert.equal(secondGoal.result.isError, false, secondGoal.result.content[0]?.text);
+      for (const [goalId, surface, idempotencyKey] of [
+        ["goal/with space", "src/runtime/contract.ts", "mcp-primary-impact"],
+        ["parallel-guide", "docs/runtime-guide.md", "mcp-parallel-impact"],
+      ]) {
+        const impact = await call(management, "goalboard_v1_impact_add", {
+          database_path: databasePath,
+          board_id: "mcp-board",
+          payload: {
+            impact: {
+              goal_id: goalId,
+              surface,
+              access: "write",
+              reason: "确认两个 Goal 的独立修改范围",
+            },
+            actor_id: "user-1",
+            idempotency_key: idempotencyKey,
+          },
+        });
+        assert.equal(impact.result.isError, false, impact.result.content[0]?.text);
+      }
+
       const availableResponse = await call(runtime, "goalboard_v1_available", {
         board_id: "mcp-board",
         actor_id: "runtime-a",
@@ -599,10 +646,36 @@ describe("mcp server", () => {
       assert.equal(availableResponse.result.isError, false, availableResponse.result.content[0]?.text);
       const available = JSON.parse(availableResponse.result.content[0].text) as {
         available: Array<{ goal: { goal_id: string }; next_action: string; role: string }>;
+        parallel_suggestion: {
+          kind: string;
+          advisory_only: boolean;
+          assignments: Array<{ runtime_slot: string; goal_id: string; role: string }>;
+        } | null;
       };
       assert.deepEqual(available.available.map((item) => [item.goal.goal_id, item.next_action, item.role]), [
         ["goal/with space", "execute", "executor"],
+        ["parallel-guide", "execute", "executor"],
       ]);
+      assert.deepEqual(available.parallel_suggestion, {
+        kind: "safe_parallel_execution",
+        advisory_only: true,
+        assignments: [
+          {
+            runtime_slot: "current_runtime",
+            goal_id: "goal/with space",
+            title: "测试稳定页面地址",
+            role: "executor",
+            required_capabilities: [],
+          },
+          {
+            runtime_slot: "additional_runtime_1",
+            goal_id: "parallel-guide",
+            title: "更新并行执行指南",
+            role: "executor",
+            required_capabilities: [],
+          },
+        ],
+      });
 
       const selectedResponse = await call(runtime, "goalboard_v1_select_goal", {
         board_id: "mcp-board",

--- a/tests/v1.test.ts
+++ b/tests/v1.test.ts
@@ -6340,6 +6340,130 @@ test("unified Available lets the Runtime choose across clarification, execution,
   store.close();
 });
 
+test("Available suggests separate Runtime slots for confirmed pairwise-safe executor Goals", () => {
+  const { store, coordinator } = fixture();
+  createLeaf(coordinator, "parallel-primary", 30);
+  createLeaf(coordinator, "parallel-secondary", 20);
+  coordinator.setPolicy(
+    "board-1",
+    {
+      goal_id: "parallel-primary",
+      policy: { required_capabilities: ["filesystem_write"] },
+      reason: "这个 Goal 需要修改本地文件",
+    },
+    { actor_id: "user-1", idempotency_key: "parallel-primary-policy" },
+  );
+  coordinator.setPolicy(
+    "board-1",
+    {
+      goal_id: "parallel-secondary",
+      policy: { required_capabilities: ["shell"] },
+      reason: "这个 Goal 需要运行命令",
+    },
+    { actor_id: "user-1", idempotency_key: "parallel-secondary-policy" },
+  );
+  coordinator.addImpact(
+    "board-1",
+    {
+      goal_id: "parallel-primary",
+      surface: "src/runtime/selection.ts",
+      access: "write",
+      reason: "修改 Runtime 选择逻辑",
+    },
+    { actor_id: "user-1", idempotency_key: "parallel-primary-impact" },
+  );
+  coordinator.addImpact(
+    "board-1",
+    {
+      goal_id: "parallel-secondary",
+      surface: "docs/runtime-guide.md",
+      access: "write",
+      reason: "更新 Runtime 使用说明",
+    },
+    { actor_id: "user-1", idempotency_key: "parallel-secondary-impact" },
+  );
+
+  const result = coordinator.queryAvailable({
+    board_id: "board-1",
+    actor_id: "runtime-current",
+    capabilities: ["filesystem_write", "shell"],
+  });
+
+  assert.deepEqual(result.parallel_suggestion, {
+    kind: "safe_parallel_execution",
+    advisory_only: true,
+    assignments: [
+      {
+        runtime_slot: "current_runtime",
+        goal_id: "parallel-primary",
+        title: "完成 parallel-primary",
+        role: "executor",
+        required_capabilities: ["filesystem_write"],
+      },
+      {
+        runtime_slot: "additional_runtime_1",
+        goal_id: "parallel-secondary",
+        title: "完成 parallel-secondary",
+        role: "executor",
+        required_capabilities: ["shell"],
+      },
+    ],
+  });
+  store.close();
+});
+
+test("Available suppresses a parallel suggestion for conflicting executor Goal impacts", () => {
+  const { store, coordinator } = fixture();
+  createLeaf(coordinator, "parallel-writer-a", 30);
+  createLeaf(coordinator, "parallel-writer-b", 20);
+  for (const goalId of ["parallel-writer-a", "parallel-writer-b"]) {
+    coordinator.addImpact(
+      "board-1",
+      {
+        goal_id: goalId,
+        surface: "src/runtime/shared.ts",
+        access: "write",
+        reason: "修改同一个 Runtime 模块",
+      },
+      { actor_id: "user-1", idempotency_key: `${goalId}-impact` },
+    );
+  }
+
+  const result = coordinator.queryAvailable({
+    board_id: "board-1",
+    actor_id: "runtime-current",
+  });
+
+  assert.equal(result.available.length, 2);
+  assert.equal(result.parallel_suggestion, null);
+  store.close();
+});
+
+test("Available does not claim safe parallelism when an executor Goal lacks confirmed impacts", () => {
+  const { store, coordinator } = fixture();
+  createLeaf(coordinator, "parallel-bounded", 30);
+  createLeaf(coordinator, "parallel-unbounded", 20);
+  coordinator.addImpact(
+    "board-1",
+    {
+      goal_id: "parallel-bounded",
+      surface: "src/runtime/bounded.ts",
+      access: "write",
+      reason: "已确认这条 Goal 的修改范围",
+    },
+    { actor_id: "user-1", idempotency_key: "parallel-bounded-impact" },
+  );
+
+  const result = coordinator.queryAvailable({
+    board_id: "board-1",
+    actor_id: "runtime-current",
+  });
+
+  assert.equal(result.available.length, 2);
+  assert.equal(result.parallel_suggestion, null);
+  store.close();
+});
+
 test("needs_changes reopens execution until a newer executor run completes", () => {
   const { store, coordinator } = fixture();
   createLeaf(coordinator, "review-rework");


### PR DESCRIPTION
## Summary
- return an advisory parallel_suggestion when executor Goals have confirmed pairwise-safe Impact boundaries
- suppress suggestions for conflicts or missing confirmed Impact data
- require fresh Available reads and individual Goal selection before any Runtime claims work
- update the GoalBoard optimization handoff

## Verification
- pnpm build: passed
- pnpm typecheck: passed
- v1 tests: 69/69 passed
- MCP tests: 25/25 passed
- full suite outside sandbox: 243/245 passed
- the two remaining install/E2E failures reproduce unchanged on main at 140d25e: LaunchAgent PID restart assertion and missing libnode.141.dylib

No force push, service installation, release, or GoalBoard ledger writes were performed.