### PR TITLE
chore: 准备发布 v0.1.4

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1156,7 +1156,7 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "goalboard-desktop"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "portable-pty",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goalboard-desktop"
-version = "0.1.3"
+version = "0.1.4"
 description = "GoalBoard macOS App: WebView plus local TUI PTY"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GoalBoard",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.adeptify.goalboard",
   "build": {
     "frontendDist": "../webview-placeholder"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adeptify/goalboard",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "GoalBoard V1：面向人和 AI Runtime 的本地 SQLite 目标真相源",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
同步 Node 包、Tauri 配置与 Rust manifest 的补丁版本，用于构建包含 GB10 服务恢复修复的 0.1.4 macOS 安装包。\n\n验证：四处版本均为 0.1.4；pnpm build 通过。