### PR TITLE
chore: 发布 GoalBoard v0.1.6

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1156,7 +1156,7 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "goalboard-desktop"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "portable-pty",
  "semver",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goalboard-desktop"
-version = "0.1.5"
+version = "0.1.6"
 description = "GoalBoard macOS App: WebView plus local TUI PTY"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GoalBoard",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.adeptify.goalboard",
   "build": {
     "frontendDist": "../webview-placeholder"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adeptify/goalboard",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "GoalBoard V1：面向人和 AI Runtime 的本地 SQLite 目标真相源",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## 版本范围

统一打包 main 上截至当前的全部改进，包括 GB05 Desktop Goal 编号回归修复与 GB16 Runtime 接入发布验收门禁。

## 工程验证

- 完整构建与默认回归：274/274
- TypeScript：通过
- `git diff --check`：通过

本 PR 只更新 package、Tauri 与 Cargo 的版本元数据；签名/安装/Runtime 接入/真实产品实操将在合入后的 Preview 资产上分别验收。