### PR TITLE
fix: 保证整份 Goal Tree 确认原子落地

### DIFF
--- a/docs/goalboard-bug-cards.md
+++ b/docs/goalboard-bug-cards.md
@@ -927,6 +927,60 @@ v0.1.5 的 GitHub Release、用户级 App、`~/.goalboard` Core 与常驻 Web se
 
 ---
 
+## GB-20260829-18：整份 Goal Tree 确认会在决定阶段部分落地
+
+**来源**：CGS 18 项 Goal Tree 变更与 Arena 7 个一级 Goal 拆分实操；两条反馈属于同一缺陷族，已去重
+**Bug 确认**：已确认，属于 GoalBoard Proposal 原子性、预检一致性和乐观并发基准缺陷；accepted Contract 不可静默改写本身是预期安全边界
+**修复决定**：需要修复，P1
+**修复状态**：源码修复、全仓工程回归和代表性 18 项 Web 产品实操已通过；最终安装 App / 新 Session 与 Owner 验收待完成
+
+### 1. 真实场景
+
+CGS Runtime 提交一份包含父 Contract 重写、新 Goal、关系和 Risk 的 18 项提案；`goal_tree_check` 返回无冲突，用户确认整份提案后，16 项已写入，两个 accepted Goal 的 Contract 更新到决定阶段才被拒绝。Arena 的整树提案也在等待用户确认期间发生根 Goal baseline 变化；决定后 7 个子 Goal 和依赖已创建，根 Contract 与全部 `part_of` 冲突，留下没有父级归属的子图。两次用户确认的都是完整 change set，而不是“能写多少先写多少”。
+
+### 2. 事实与归因
+
+两条路径均可由当前实现解释并回归复现。`goal_tree_check` 只检查条目格式、Risk 校验和调用方提供的对象 hash，没有运行决定阶段的 materialization invariant，因此 accepted Contract 的 `goal.accepted_compound_closure_invalid` 只能在 decide 暴露。`confirm_all_pending` 随后被展开成普通逐项 confirm；materializer 遇到冲突时记录该 item，继续写入其余条目，最终形成 `partially_applied`。Goal baseline 又对完整 `GoalRecord` 做 hash，把 `updated_at`、`fulfillment_state` 等不属于该 Contract / relation 条目写入面的字段也算作并发变更；关系端点是否进入 affected objects 还依赖消费者手填。主要归因是 GoalBoard Core 缺陷。accepted Goal 只能做已允许的 compound closure、不能借需求变化静默重写已接受业务 Contract，是保护历史 Evidence 与用户承诺的预期行为；缺陷在于系统在确认前不说明、确认后又只落一半。
+
+### 3. 现有流程的问题
+
+Runtime 按规范 propose → read → check → 请求用户确认，仍无法知道整份方案不可应用。用户确认后 canonical tree 才暴露错误，而且已写入的 Goal、依赖、Risk 与未写入的核心 Contract 形成语义不一致。Runtime 不知道应重试、修改原 Goal、创建 successor 还是回滚已落结构；`revision_proposals=[]` 也没有直接恢复路径。Arena 中普通等待和租约到期还会让与 Contract 无关的根版本自然漂移，迫使用户再次确认。
+
+### 4. 设计根因与初衷
+
+逐项 materialization 的初衷是让一份复杂提案中的独立安全条目不会被另一个并发冲突永久拖住；全对象 optimistic hash 的初衷是简单、保守地阻止在旧事实上覆盖新状态；accepted Contract 不可变则防止已经执行和验收过的承诺被改写。这些保护在“用户逐项决定”时合理。缺陷是 `confirm_all_pending` 沿用了逐项容错语义，系统没有表达“用户决定的原子单位”；同时保守 hash 没有按 item 的真实写入面收敛，正常运行态变化也被误当成业务冲突。
+
+### 5. 当前影响
+
+影响所有包含多 Goal、多关系和 Contract 更新的整树提案，等待用户确认越久、条目越多，触发概率越高。它不会破坏 SQLite 事务完整性，但会破坏用户确认的语义完整性：用户批准一条新主链路，系统却生成一半新结构和一半旧合同。后续 Agent 可能在孤立或错误归属的 Goal 上继续执行，`planning_graph_check` 仍可能因没有循环和缺失引用而显示绿色。本次已分别在 CGS 与 Arena 真实阻断规划闭环。
+
+### 6. 复杂度审查
+
+- **当前必须**：`confirm_all_pending` 全有或全无；任一 baseline、规划或 materialization 冲突都回滚整次决定并明确下一步。`goal_tree_check` 在可回滚 savepoint 中按真实物化顺序运行同一不变量。新 Proposal 的对象版本按 item 真正依赖的 canonical 字段计算，排除时间戳和执行派生状态；旧 Proposal 保持 legacy hash 兼容。relation / dependency 自动把两端 Goal 加入 affected objects，不再依赖消费者手填完整。
+- **可以延后**：自动创建 successor Goal、把 accepted Contract 的需求变更自动翻译成 revision/successor 提案、历史 `partially_applied` 的一键补偿、跨 Proposal 事务、在通用 graph check 中推断所有业务孤儿。
+- **应当删除**：把整份确认静默降级成逐项尽力写入；check 只看格式和 hash 却展示为“可应用”；用 `updated_at`、Claim / Run 派生状态或无关完成状态让 Contract Proposal 自然失效；依赖消费者记住把每个关系端点重复写进 affected objects。
+
+### 7. 修复必要性与优先级
+
+需要修复，P1。问题直接破坏用户确认与 canonical 写入之间的一致性，并已经留下真实部分结构。最小修复可以复用现有 SQLite immediate transaction、materializer 和 savepoint，不需要新增数据库、队列或第二套 Proposal 模型。accepted Goal 的需求变化策略仍需由规划层显式选择 successor 或允许的收口，本卡不放宽不可变边界。
+
+### 8. 修复前后体验差异
+
+- **修复前**：Runtime check 显示无冲突 → 用户确认 18 项整体方向 → 16 项已落、2 项才报错 → 用户面对不一致的半棵树，并被迫猜恢复方式。
+- **修复后**：Runtime check 在确认前指出具体不可应用条目及原 invariant → Runtime 先修订或改用 successor，再请求用户确认；即使跳过 check 直接整份确认，任何冲突也会返回“本次没有写入任何变更”。只有用户明确逐项选择时，互不依赖的安全条目才允许分别落地。等待期间的 Claim、Run、时间戳或完成派生状态不再让无关 Contract / relation baseline 失效。
+
+### 9. 最小修复范围
+
+只修改 Goal Tree Proposal 的 normalize、baseline、check 和 decide：关系条目自动补齐端点 affected objects；新 baseline 写入带版本前缀的语义 hash，旧无前缀 baseline 继续按旧方式比较；check 在数据库 savepoint 内调用现有 materializer，逐条回滚预检写入；whole confirmation 遇到任何冲突抛出结构化 `goal_tree_proposal.whole_confirmation_conflict`，由外层 immediate transaction 回滚所有已模拟或已物化条目。保留显式逐项 decisions 的 `partially_applied` 语义，不修改 accepted Contract 不可变规则，不自动删除两次真实事故已落地的数据。回滚无需 schema migration。
+
+### 10. 验收边界
+
+- **工程验证**：通过。新增回归证明 check 能在决定前发现 accepted Contract 的 materialization conflict；跳过 check 的整份确认会抛出结构化冲突，安全 Goal、item decision 与 Proposal state 全部保持未写入；新语义 baseline 忽略 `fulfillment_state / updated_at`，但 Contract 标题变化仍只冲突 Contract item；relation 自动记录两端 Goal，且根标题变化不会误伤关系；已部分落地的旧 Proposal 不能再次伪装成整份原子确认。原有显式逐项部分落地测试保持通过，TypeScript 构建、typecheck、`git diff --check` 与全仓 278/278 通过。首次沙箱运行因测试临时 SQLite 与 `~/.npm` 日志无写权限出现 21 个环境失败，已在正常权限下完整重跑归零；没有把环境失败计作通过。
+- **产品实操**：源码构建下通过代表性主路径。用同一真实 Web 决定页同时放入合法 18 项 Proposal 与含 accepted Contract 冲突的 Proposal：合法方案填写理由并点击一次“采用整份方案”后，18/18 item、9 个子 Goal 与 9 条 `part_of` 同时落地；冲突方案在确认前显示具体 invariant 与 successor / replacement 恢复建议，确认按钮不可用，直接调用整份确认接口也返回 400，安全 Goal 未创建、原 accepted Contract 未改、所有 decision 仍为空；浏览器 console 无 warning/error。真实 CGS / Arena 历史 `partially_applied` 数据不在本卡自动补偿范围，最终安装 App / 新 Session 仍为 `UNVERIFIED`。
+- **Owner 最终验收**：未通过。需在最终安装包的新 Session 中分别验证“合法大型整份提案一次落地”和“一个 accepted Contract 不可修改时整份零写入”，并由用户确认错误说明足以判断该修订原 Goal、创建 successor 还是放弃变更。
+
+---
+
 ## GB-20260830-19：桌面健康恢复与 LaunchAgent 修复互相抢占 4173
 
 **来源**：v0.1.6 最终 App 安装后的服务修复实操

--- a/skills/goal-advance/references/planning.md
+++ b/skills/goal-advance/references/planning.md
@@ -236,6 +236,8 @@ A ready leaf has no unresolved decision or independent deliverable, covers every
 
 Use one `goalboard_v1_goal_tree_propose` for the complete change set, then `goalboard_v1_goal_tree_read` and `goalboard_v1_goal_tree_check`. Include parent and child Goal/Contract changes, `part_of`, `depends_on`, Risks, Policy, Candidates, and Rewires where applicable.
 
+Treat `goalboard_v1_goal_tree_check` as the required preflight before asking the user to decide: it checks semantic baselines and dry-runs the same materialization invariants without changing the canonical tree. If it returns any conflict or planning issue, explain and revise first. `confirm_all_pending` is all-or-nothing: one stale or invalid item leaves every pending item untouched. Use explicit per-item decisions only when the user intentionally wants independent safe items to land separately; do not turn a failed whole change set into an implicit partial application.
+
 For a Risk item, keep treatment strategy and lifecycle state separate. `treatment` is one of `accept | mitigate | avoid | defer`; optional `state` is one of `open | triggered | resolved | accepted | expired`. There is no `state=mitigated`: after mitigation work is actually complete, propose `state=resolved`. New Risks start `open`. After a confirmed Risk update, re-read the canonical Contract and verify its state before claiming that a completion blocker is cleared.
 
 To promote an existing pending Candidate, do not create a second Candidate or call a separate decision path. Add one `kind=candidate`, `operation=update` item to the unified Proposal:

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -769,7 +769,7 @@ const V1_TOOLS: McpToolDefinition[] = [
   {
     name: "goalboard_v1_goal_tree_check",
     description:
-      "按每个条目保存的对象基准检查并持久化并发冲突；某个条目冲突不会丢弃未冲突条目。",
+      "按每个条目真正依赖的 canonical 事实检查并发变化，并在可回滚预检中运行与决定阶段相同的物化不变量；某个条目冲突不会改写 canonical Goal Tree，也不会隐藏其他条目的检查结果。",
     inputSchema: {
       type: "object",
       properties: {
@@ -784,7 +784,7 @@ const V1_TOOLS: McpToolDefinition[] = [
   {
     name: "goalboard_v1_goal_tree_decide",
     description:
-      "把用户对 Goal Tree 提案的逐项确认、拒绝或修订原子物化；管理入口必须提供可审计的用户与消息引用。",
+      "把用户对 Goal Tree 提案的决定物化；逐项决定仍允许互不依赖的安全条目分别落地，confirm_all_pending 则全有或全无，任一冲突都会让整份确认保持未写入。管理入口必须提供可审计的用户与消息引用。",
     inputSchema: {
       type: "object",
       properties: {
@@ -1424,7 +1424,7 @@ function runtimeToolDefinition(tool: McpToolDefinition): McpToolDefinition {
         ["user_confirmed", "confirmation_summary"],
       );
     clone.description =
-      "在当前 Runtime 对话中执行用户已经明确表达的 Goal Tree 决定。必须传 user_confirmed=true 和确认摘要；GoalBoard 结合 MCP 宿主会话元数据记录审计来源，不把 Runtime 声明伪装成密码学证明。";
+      "在当前 Runtime 对话中执行用户已经明确表达的 Goal Tree 决定。必须传 user_confirmed=true 和确认摘要；confirm_all_pending 全有或全无，任一冲突都会保持整份提案未写入，逐项 decisions 才允许独立安全条目分别落地。GoalBoard 结合 MCP 宿主会话元数据记录审计来源，不把 Runtime 声明伪装成密码学证明。";
     return clone;
   }
   if (tool.name !== "goalboard_v1_review_submit") return clone;

--- a/src/v1/coordinator.ts
+++ b/src/v1/coordinator.ts
@@ -645,7 +645,8 @@ function normalizeGoalTreeProposalItems(
       );
     }
     const seenObjects = new Set<string>();
-    const affectedObjects = item.affected_objects.map((object, objectIndex) => {
+    const affectedObjects: ProposalAffectedObject[] = [];
+    const addAffectedObject = (object: ProposalAffectedObject, objectIndex: number): void => {
       if (!PROPOSAL_AFFECTED_OBJECT_TYPES.has(object.object_type)) {
         throw new GoalBoardV1Error(
           "goal_tree_proposal.affected_object_type_invalid",
@@ -660,10 +661,21 @@ function normalizeGoalTreeProposalItems(
         );
       }
       const key = `${object.object_type}:${objectId}`;
-      if (seenObjects.has(key)) return null;
+      if (seenObjects.has(key)) return;
       seenObjects.add(key);
-      return { object_type: object.object_type, object_id: objectId };
-    }).filter((object): object is ProposalAffectedObject => object != null);
+      affectedObjects.push({ object_type: object.object_type, object_id: objectId });
+    };
+    item.affected_objects.forEach(addAffectedObject);
+    if (item.kind === "relation" || item.kind === "dependency") {
+      for (const relation of goalTreeProposalRelationPayloads(item, index)) {
+        const relationId = String(relation.relation_id ?? "").trim();
+        const fromGoalId = String(relation.from_goal_id ?? "").trim();
+        const toGoalId = String(relation.to_goal_id ?? "").trim();
+        if (relationId) addAffectedObject({ object_type: "relation", object_id: relationId }, affectedObjects.length);
+        if (fromGoalId) addAffectedObject({ object_type: "goal", object_id: fromGoalId }, affectedObjects.length);
+        if (toGoalId) addAffectedObject({ object_type: "goal", object_id: toGoalId }, affectedObjects.length);
+      }
+    }
     if (affectedObjects.length === 0) {
       throw new GoalBoardV1Error("goal_tree_proposal.affected_objects_required", `第 ${index + 1} 个条目必须标出受影响对象`);
     }
@@ -3177,7 +3189,7 @@ export class GoalBoardCoordinator {
       `);
       for (const [index, item] of items.entries()) {
         const baselineVersions = item.affected_objects.map((object) =>
-          this.proposalObjectVersion(input.board_id, object),
+          this.proposalObjectVersion(input.board_id, object, item),
         );
         insertItem.run(
           item.item_id,
@@ -3289,7 +3301,7 @@ export class GoalBoardCoordinator {
       if (replay) return replay;
       const proposal = this.readNativeGoalTreeProposal(input.board_id, proposalId);
       const now = this.clock().toISOString();
-      const conflictItemIds: string[] = [];
+      const conflictItemIdSet = new Set<string>();
       const updateItem = this.store.db.prepare(`
         UPDATE goal_tree_proposal_items
         SET state = ?, conflict_json = ?, updated_at = ?
@@ -3299,7 +3311,7 @@ export class GoalBoardCoordinator {
         if (item.state !== "pending" && item.state !== "conflict") continue;
         const validationIssue = goalTreeProposalItemValidationIssues(item)[0];
         const baselineConflicts = item.baseline_versions.flatMap((baseline) => {
-          const current = this.proposalObjectVersion(input.board_id, baseline);
+          const current = this.proposalObjectVersionForBaseline(input.board_id, baseline, item);
           return baseline.exists === current.exists && baseline.version === current.version
             ? []
             : [{ object: { object_type: baseline.object_type, object_id: baseline.object_id }, baseline, current }];
@@ -3314,9 +3326,26 @@ export class GoalBoardCoordinator {
           : baselineConflicts.length > 0
             ? { objects: baselineConflicts }
             : null;
-        if (conflict) conflictItemIds.push(item.item_id);
+        if (conflict) conflictItemIdSet.add(item.item_id);
         updateItem.run(conflict ? "conflict" : "pending", conflict ? sqliteJson(conflict) : null, now, item.item_id, proposalId);
       }
+      const checkedItems = this.readNativeGoalTreeProposal(input.board_id, proposalId).items;
+      const materializationConflicts = this.preflightGoalTreeProposalMaterialization(
+        input.board_id,
+        checkedItems.filter((item) => item.state === "pending"),
+        actorId,
+        now,
+      );
+      for (const item of checkedItems) {
+        const conflict = materializationConflicts.get(item.item_id);
+        if (!conflict) continue;
+        conflictItemIdSet.add(item.item_id);
+        updateItem.run("conflict", sqliteJson(conflict), now, item.item_id, proposalId);
+      }
+      const conflictItemIds = proposal.items
+        .filter((item) => conflictItemIdSet.has(item.item_id))
+        .map((item) => item.item_id);
+      const planningIssues = this.goalTreePlanningIssues(input.board_id, proposal.items);
       const cursor = this.store.appendEvent({
         eventId: randomUUID(),
         boardId: input.board_id,
@@ -3329,14 +3358,14 @@ export class GoalBoardCoordinator {
           : "当前 Runtime 检查到 Goal Tree 提案的各条目基准仍有效",
         payload: {
           conflict_item_ids: conflictItemIds,
-          planning_issue_codes: this.goalTreePlanningIssues(input.board_id, proposal.items).map((issue) => issue.code),
+          planning_issue_codes: planningIssues.map((issue) => issue.code),
         },
         at: now,
       });
       const outcome: GoalTreeProposalCheckResult = {
         proposal: this.readNativeGoalTreeProposal(input.board_id, proposalId),
         conflict_item_ids: conflictItemIds,
-        planning_issues: this.goalTreePlanningIssues(input.board_id, proposal.items),
+        planning_issues: planningIssues,
         observed_event_cursor: cursor,
       };
       this.remember(
@@ -3353,12 +3382,13 @@ export class GoalBoardCoordinator {
   }
 
   /**
-   * Applies only the user-confirmed subset of one native Goal Tree proposal.
-   * A stale or structurally unsafe item becomes a persisted conflict while
-   * independent confirmed items in the same composite decision still land.
+   * Applies either an explicitly selected subset or one pristine whole proposal.
+   * Subset decisions preserve independent-item conflict handling; whole confirmation
+   * is all-or-nothing and rolls the transaction back when any item cannot land.
    */
   decideGoalTreeProposal(input: GoalTreeProposalDecideInput): GoalTreeProposalDecisionResult {
     const authority = normalizeGoalTreeProposalDecisionAuthority(input.authority);
+    const wholeConfirmation = input.confirm_all_pending === true;
     const proposalId = requiredDialogueText(
       input.proposal_id,
       "goal_tree_proposal.id_required",
@@ -3372,7 +3402,7 @@ export class GoalBoardCoordinator {
       authority,
       decisions: input.decisions ?? [],
       reason: input.reason ?? null,
-      confirm_all_pending: input.confirm_all_pending === true,
+      confirm_all_pending: wholeConfirmation,
     });
     return this.store.immediate(() => {
       const replay = this.replay<Omit<GoalTreeProposalDecisionResult, "replayed">>(
@@ -3392,13 +3422,41 @@ export class GoalBoardCoordinator {
           "只有仍有待处理条目的 Goal Tree 提案可以继续决定",
         );
       }
+      const abortWholeConfirmation = (
+        item: GoalTreeProposalItemRecord,
+        conflict: Record<string, unknown>,
+      ): never => {
+        const detail = String(conflict.message ?? conflict.code ?? "当前事实与提案不一致");
+        const recovery = String(conflict.recovery ?? this.goalTreeProposalConflictRecovery(conflict));
+        throw new GoalBoardV1Error(
+          "goal_tree_proposal.whole_confirmation_conflict",
+          `整份提案中的条目「${item.item_id}」暂时不能采用：${detail}。本次整份确认没有写入任何变更；${recovery}`,
+          {
+            item_id: item.item_id,
+            original_code: conflict.code ?? null,
+            conflict,
+            next_action: "check_and_revise",
+          },
+        );
+      };
 
       let decisions = normalizeGoalTreeProposalDecisions(input.decisions, input.reason);
-      if (input.confirm_all_pending === true) {
+      if (wholeConfirmation) {
         if (decisions.length > 0) {
           throw new GoalBoardV1Error(
             "goal_tree_proposal.whole_confirmation_mixed",
             "整份确认不能同时携带逐项决定；请二选一",
+          );
+        }
+        if (proposal.state !== "pending") {
+          throw new GoalBoardV1Error(
+            "goal_tree_proposal.whole_confirmation_requires_pristine_proposal",
+            "这份提案已经有条目落地，不能再作为一份完整变更原子确认；请基于当前 Goal Tree 生成只包含未落地内容的修订提案",
+            {
+              proposal_id: proposal.proposal_id,
+              state: proposal.state,
+              next_action: "create_revision_from_current_tree",
+            },
           );
         }
         const activeProposals = this.store
@@ -3410,14 +3468,20 @@ export class GoalBoardCoordinator {
           );
         if (
           authority.whole_confirmation_prompted !== true ||
-          activeProposals.length !== 1 ||
-          activeProposals[0]?.proposal_id !== proposal.proposal_id ||
-          proposal.items.some((item) => item.state === "conflict")
+          (authority.authority_source === "runtime_dialogue" &&
+            (activeProposals.length !== 1 || activeProposals[0]?.proposal_id !== proposal.proposal_id))
         ) {
           throw new GoalBoardV1Error(
             "goal_tree_proposal.whole_confirmation_ambiguous",
             "简短确认只有在上一问明确请求确认唯一整份提案时才能生效；请说明要确认哪些条目",
           );
+        }
+        const existingConflict = proposal.items.find((item) => item.state === "conflict");
+        if (existingConflict) {
+          abortWholeConfirmation(existingConflict, existingConflict.conflict ?? {
+            code: "goal_tree_proposal.item_conflict",
+            message: "条目与当前 GoalBoard 事实不一致",
+          });
         }
         const sharedReason = requiredDialogueText(
           input.reason ?? "",
@@ -3524,6 +3588,15 @@ export class GoalBoardCoordinator {
         if (decision.decision === "revise") continue;
         const planningConflict = planningConflicts.get(item.item_id);
         if (planningConflict) {
+          if (wholeConfirmation) {
+            abortWholeConfirmation(item, {
+              code: planningConflict.code,
+              message: planningConflict.message,
+              goal_ids: planningConflict.goal_ids,
+              relation_ids: planningConflict.relation_ids,
+              path: planningConflict.path,
+            });
+          }
           this.recordGoalTreeProposalItemDecision({
             board_id: input.board_id,
             proposal_id: proposal.proposal_id,
@@ -3549,6 +3622,13 @@ export class GoalBoardCoordinator {
         }
         const conflicts = this.goalTreeProposalItemConflicts(input.board_id, item);
         if (conflicts.length > 0) {
+          if (wholeConfirmation) {
+            abortWholeConfirmation(item, {
+              code: "goal_tree_proposal.baseline_changed",
+              message: "条目依赖的 GoalBoard 事实已经变化",
+              objects: conflicts,
+            });
+          }
           this.recordGoalTreeProposalItemDecision({
             board_id: input.board_id,
             proposal_id: proposal.proposal_id,
@@ -3578,6 +3658,7 @@ export class GoalBoardCoordinator {
         for (const entry of confirmed.filter((candidate) => kinds.includes(candidate.item.kind))) {
           const conflict = this.goalTreeProposalMaterializationConflict(input.board_id, entry.item);
           if (conflict) {
+            if (wholeConfirmation) abortWholeConfirmation(entry.item, conflict);
             this.recordGoalTreeProposalItemDecision({
               board_id: input.board_id,
               proposal_id: proposal.proposal_id,
@@ -3595,13 +3676,25 @@ export class GoalBoardCoordinator {
             conflictItemIds.push(entry.item.item_id);
             continue;
           }
-          const materializedObjects = this.materializeGoalTreeProposalItem(
-            input.board_id,
-            entry.item,
-            authority.actor_id,
-            entry.decision.reason,
-            now,
-          );
+          let materializedObjects: ProposalAffectedObject[];
+          try {
+            materializedObjects = this.materializeGoalTreeProposalItem(
+              input.board_id,
+              entry.item,
+              authority.actor_id,
+              entry.decision.reason,
+              now,
+            );
+          } catch (error) {
+            if (wholeConfirmation && error instanceof GoalBoardV1Error) {
+              abortWholeConfirmation(entry.item, {
+                code: error.code,
+                message: error.message,
+                ...(error.details ?? {}),
+              });
+            }
+            throw error;
+          }
           this.recordGoalTreeProposalItemDecision({
             board_id: input.board_id,
             proposal_id: proposal.proposal_id,
@@ -6871,7 +6964,11 @@ export class GoalBoardCoordinator {
     return proposal;
   }
 
-  private proposalObjectVersion(boardId: string, object: ProposalAffectedObject): ProposalObjectVersion {
+  private proposalObjectVersion(
+    boardId: string,
+    object: ProposalAffectedObject,
+    item?: Pick<GoalTreeProposalItemRecord, "kind" | "operation">,
+  ): ProposalObjectVersion {
     const snapshot = this.store.snapshot(boardId);
     let current: unknown = null;
     switch (object.object_type) {
@@ -6900,8 +6997,76 @@ export class GoalBoardCoordinator {
       object_type: object.object_type,
       object_id: object.object_id,
       exists: current != null,
-      version: current == null ? "absent" : requestHash(current),
+      version: current == null
+        ? "absent"
+        : item
+          ? `semantic-v1:${requestHash(this.proposalSemanticObject(current, object, item))}`
+          : requestHash(current),
     };
+  }
+
+  private proposalObjectVersionForBaseline(
+    boardId: string,
+    baseline: ProposalObjectVersion,
+    item: Pick<GoalTreeProposalItemRecord, "kind" | "operation">,
+  ): ProposalObjectVersion {
+    return this.proposalObjectVersion(
+      boardId,
+      baseline,
+      baseline.version === "absent" || baseline.version.startsWith("semantic-v1:") ? item : undefined,
+    );
+  }
+
+  private proposalSemanticObject(
+    current: unknown,
+    object: ProposalAffectedObject,
+    item: Pick<GoalTreeProposalItemRecord, "kind" | "operation">,
+  ): unknown {
+    if (!current || typeof current !== "object" || Array.isArray(current)) return current;
+    const record = current as Record<string, unknown>;
+    if (object.object_type === "goal" && (item.kind === "goal" || item.kind === "contract")) {
+      const fields = [
+        "goal_id",
+        "board_id",
+        "title",
+        "outcome",
+        "why",
+        "business_logic",
+        "in_scope",
+        "out_of_scope",
+        "constraints",
+        "required_inputs",
+        "promised_outputs",
+        "decomposition_review",
+        "definition_state",
+        "decomposition_state",
+        "trashed_at",
+        "trashed_by",
+        "archived_at",
+        "archived_by",
+        "priority",
+        "acceptance_criteria",
+      ];
+      return Object.fromEntries(fields.map((field) => [field, record[field]]));
+    }
+    if (object.object_type === "goal") {
+      return {
+        goal_id: record.goal_id,
+        board_id: record.board_id,
+        definition_state: record.definition_state,
+        decomposition_state: record.decomposition_state,
+        trashed_at: record.trashed_at,
+        archived_at: record.archived_at,
+      };
+    }
+    return Object.fromEntries(
+      Object.entries(record).filter(([field]) => ![
+        "created_at",
+        "updated_at",
+        "decided_at",
+        "deactivated_at",
+      ].includes(field)),
+    );
   }
 
   private goalTreeProposalItemConflicts(
@@ -6909,7 +7074,7 @@ export class GoalBoardCoordinator {
     item: GoalTreeProposalItemRecord,
   ): Array<Record<string, unknown>> {
     return item.baseline_versions.flatMap((baseline) => {
-      const current = this.proposalObjectVersion(boardId, baseline);
+      const current = this.proposalObjectVersionForBaseline(boardId, baseline, item);
       return baseline.exists === current.exists && baseline.version === current.version
         ? []
         : [{
@@ -7147,7 +7312,7 @@ export class GoalBoardCoordinator {
     `);
     for (const [index, revision] of revisions.entries()) {
       const item = revision.revised_item;
-      const baselineVersions = item.affected_objects.map((object) => this.proposalObjectVersion(boardId, object));
+      const baselineVersions = item.affected_objects.map((object) => this.proposalObjectVersion(boardId, object, item));
       insertItem.run(
         item.item_id,
         proposalId,
@@ -7833,6 +7998,62 @@ export class GoalBoardCoordinator {
         : null;
     }
     return null;
+  }
+
+  private preflightGoalTreeProposalMaterialization(
+    boardId: string,
+    items: GoalTreeProposalItemRecord[],
+    actorId: string,
+    at: string,
+  ): Map<string, Record<string, unknown>> {
+    const conflicts = new Map<string, Record<string, unknown>>();
+    const materializationOrder: GoalTreeProposalItemRecord["kind"][][] = [
+      ["goal", "contract", "candidate"],
+      ["policy", "risk"],
+      ["relation", "dependency", "rewire"],
+    ];
+    this.store.db.exec("SAVEPOINT goal_tree_materialization_preflight");
+    try {
+      for (const kinds of materializationOrder) {
+        for (const item of items.filter((candidate) => kinds.includes(candidate.kind))) {
+          this.store.db.exec("SAVEPOINT goal_tree_item_preflight");
+          try {
+            const conflict = this.goalTreeProposalMaterializationConflict(boardId, item);
+            if (conflict) {
+              conflicts.set(item.item_id, {
+                ...conflict,
+                recovery: this.goalTreeProposalConflictRecovery(conflict),
+              });
+              this.store.db.exec("ROLLBACK TO goal_tree_item_preflight");
+              this.store.db.exec("RELEASE goal_tree_item_preflight");
+              continue;
+            }
+            this.materializeGoalTreeProposalItem(boardId, item, actorId, "Goal Tree 提案只读预检", at);
+            this.store.db.exec("RELEASE goal_tree_item_preflight");
+          } catch (error) {
+            this.store.db.exec("ROLLBACK TO goal_tree_item_preflight");
+            this.store.db.exec("RELEASE goal_tree_item_preflight");
+            if (!(error instanceof GoalBoardV1Error)) throw error;
+            conflicts.set(item.item_id, {
+              code: error.code,
+              message: error.message,
+              ...(error.details ?? {}),
+              recovery: this.goalTreeProposalConflictRecovery({ code: error.code }),
+            });
+          }
+        }
+      }
+    } finally {
+      this.store.db.exec("ROLLBACK TO goal_tree_materialization_preflight");
+      this.store.db.exec("RELEASE goal_tree_materialization_preflight");
+    }
+    return conflicts;
+  }
+
+  private goalTreeProposalConflictRecovery(conflict: Record<string, unknown>): string {
+    return String(conflict.code ?? "").startsWith("goal.accepted_")
+      ? "已接受 Goal 的业务 Contract 不能原地重写；若需求已经变化，请创建 successor / replacement Goal，或只提交允许的 closed_compound 收口，再让用户确认。当前 Goal Tree 尚未改变。"
+      : "请先运行 goal_tree_check 并修订这个条目，再让用户决定整份提案。当前 Goal Tree 尚未改变。";
   }
 
   private materializeGoalTreeProposalItem(

--- a/src/web/i18n.ts
+++ b/src/web/i18n.ts
@@ -2247,7 +2247,7 @@ Object.assign(EN, {
   "其中 {count} 条风险信息需要 Runtime 修正。这些风险还没有写入 GoalBoard，所以不会出现单独的“风险处理”入口。": "The Runtime must correct {count} risk items. These risks have not been added to GoalBoard yet, so they do not have separate risk-decision entries.",
   "其中 {count} 个 Goal 还没有交代产品关键路径，或下面仍有目标没有拆完。": "{count} Goal(s) still lack clear product-path ownership or contain child Goals that need more breakdown.",
   "其中 {count} 个 Goal 还没有交代通用结果链、当前任务的必要路径，或下面仍有目标没有拆完。": "{count} Goal(s) still lack the shared result chain, task-specific paths, or contain child Goals that need more breakdown.",
-  "其中有风险信息或 Goal 拆解需要 Runtime 修正，修正前不会写入 Goal Tree。": "The Runtime must correct risk information or Goal breakdowns before anything can be written to the Goal Tree.",
+  "当前有内容不满足 GoalBoard 的写入规则，修正前不会写入 Goal Tree。": "Some content does not meet GoalBoard's write rules. Nothing will be written to the Goal Tree until it is corrected.",
   "你现在需要做：写明退回原因，然后点击“退回并要求修正”。": "What to do now: explain what needs correction, then select “Return for correction.”",
   "有 {count} 项需要先修正": "{count} items need correction first",
   "退回并要求修正": "Return for correction",

--- a/src/web/render.ts
+++ b/src/web/render.ts
@@ -2684,7 +2684,14 @@ function renderGoalTreeProposalDecision(proposal: GoalTreeProposalRecord, view: 
   }
   const issuesByItem = new Map<string, Array<{ message: string; recovery: string }>>();
   for (const item of undecidedItems) {
+    const persistedConflict = item.state === "conflict"
+      ? [{
+          message: String(item.conflict?.message ?? L("这份方案仍有不能安全写入的内容，需要修正后再确认。")),
+          recovery: String(item.conflict?.recovery ?? L("当前 Goal Tree 不会改变；Runtime 会根据你的意见重新整理方案。")),
+        }]
+      : [];
     const issues = [
+      ...persistedConflict,
       ...(riskIssuesByItem.get(item.item_id) ?? []).map(goalTreeProposalIssueCopy),
       ...(decompositionIssuesByItem.get(item.item_id) ?? []).map((issue) =>
         goalTreeDecompositionIssueCopy(issue, view, proposal)),
@@ -2781,7 +2788,7 @@ function renderGoalTreeProposalDecision(proposal: GoalTreeProposalRecord, view: 
         ? L("这些 Goal 仍包含多个可独立交付的结果，或没有说明唯一主要结果和完成依据。", { count: leafInvalidItemCount })
         : decompositionOnly
         ? L("其中 {count} 个 Goal 还没有交代通用结果链、当前任务的必要路径，或下面仍有目标没有拆完。", { count: invalidItemCount })
-        : L("其中有风险信息或 Goal 拆解需要 Runtime 修正，修正前不会写入 Goal Tree。");
+        : L("当前有内容不满足 GoalBoard 的写入规则，修正前不会写入 Goal Tree。");
   const invalidWhy = repairableRiskItemCount
     ? L("风险怎么处理应当由你决定。GoalBoard 会把处理类别和具体措施分开保存，并保留方案的其他内容。")
     : riskOnly
@@ -8589,7 +8596,9 @@ const CLIENT_SCRIPT = `
             method: "POST",
             headers: goalboardControlHeaders(),
             body: JSON.stringify({
-              decisions: itemIds.map((itemId) => ({ item_id: itemId, decision, reason })),
+              ...(decision === "confirm"
+                ? { confirm_all_pending: true }
+                : { decisions: itemIds.map((itemId) => ({ item_id: itemId, decision, reason })) }),
               reason,
             }),
           });

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -2756,18 +2756,13 @@ async function handleGoalBoardWebRequest(
             }
             return;
           }
-          if (body.confirm_all_pending === true) {
-            sendJson(response, 400, {
-              error: "Web 入口不能验证上一轮是否明确请求整份确认；请逐项选择，或在当前 Runtime 对话中确认整份提案。",
-            });
-            return;
-          }
           if (body.decisions != null && !Array.isArray(body.decisions)) {
             sendJson(response, 400, { error: "decisions 必须是条目决定列表" });
             return;
           }
           try {
             const proposalId = decodeURIComponent(goalTreeProposalMatch[1]);
+            const confirmsWholeProposal = body.confirm_all_pending === true;
             let decisions = body.decisions as Parameters<GoalBoardCoordinator["decideGoalTreeProposal"]>[0]["decisions"];
             let decisionReason = typeof body.reason === "string" ? body.reason.trim() : "";
             if (Array.isArray(decisions) && decisions.length > 0 && decisions.every((decision) => decision.decision === "reject")) {
@@ -2808,9 +2803,11 @@ async function handleGoalBoardWebRequest(
                 authority_source: "web",
                 conversation_ref: `web:${options.boardId}`,
                 message_ref: `web-decision:${randomUUID()}`,
+                whole_confirmation_prompted: confirmsWholeProposal,
               },
               decisions,
               reason: decisionReason || undefined,
+              confirm_all_pending: confirmsWholeProposal,
               idempotency_key: String(body.idempotency_key ?? `web-goal-tree-decision-${randomUUID()}`),
             });
             sendJson(response, 200, result);

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -144,6 +144,8 @@ describe("mcp server", () => {
     assert.match(explainTool?.description ?? "", /ready 只表示执行 Claim 就绪/);
     assert.ok(names.includes("goalboard_v1_goal_tree_read"));
     assert.ok(names.includes("goalboard_v1_goal_tree_check"));
+    const goalTreeCheckTool = listedTools.find((tool) => tool.name === "goalboard_v1_goal_tree_check");
+    assert.match(goalTreeCheckTool?.description ?? "", /物化不变量/);
     assert.ok(names.includes("goalboard_v1_planning_methods"));
     const planningMethodsTool = listedTools.find((tool) => tool.name === "goalboard_v1_planning_methods");
     assert.match(planningMethodsTool?.description ?? "", /methods\[\].*instructions/);
@@ -239,6 +241,7 @@ describe("mcp server", () => {
     const trashListTool = listedTools.find((tool) => tool.name === "goalboard_v1_goal_trash_list");
     assert.deepEqual(trashListTool?.inputSchema.properties?.payload.required, []);
     const treeDecisionTool = listedTools.find((tool) => tool.name === "goalboard_v1_goal_tree_decide");
+    assert.match(treeDecisionTool?.description ?? "", /confirm_all_pending 全有或全无/);
     assert.ok(treeDecisionTool?.inputSchema.properties?.runtime_actor_id);
     assert.ok(treeDecisionTool?.inputSchema.properties?.user_confirmed);
     assert.ok(treeDecisionTool?.inputSchema.properties?.confirmation_summary);
@@ -445,6 +448,8 @@ describe("mcp server", () => {
     assert.match(references.planning, /work type describes the shape of work/);
     assert.match(references.planning, /vertical outcome unit/);
     assert.match(references.planning, /horizontal shared unit/);
+    assert.match(references.planning, /confirm_all_pending.*all-or-nothing/);
+    assert.match(references.planning, /failed whole change set.*implicit partial application/);
     assert.match(references.execution, /GoalBoard does not dispatch one mandatory next task/);
     assert.match(references.execution, /An observed mismatch is Goal information/);
     assert.match(references["service-start"], /service status --home "\$HOME\/\.goalboard" --json/);

--- a/tests/v1.test.ts
+++ b/tests/v1.test.ts
@@ -3523,7 +3523,23 @@ test("a clarifier submits one atomic, versioned Goal Tree proposal without touch
     ["goal", "contract", "relation", "dependency", "risk", "policy", "candidate", "rewire"],
   );
   assert.ok(submitted.proposal.items.every((item) => item.requires_user_confirmation));
-  assert.ok(submitted.proposal.items.every((item) => item.baseline_versions.length === 1));
+  assert.deepEqual(
+    submitted.proposal.items.find((item) => item.item_id === "item-parent-child")?.affected_objects,
+    [
+      { object_type: "relation", object_id: "relation:new:first-use-guide:tree-root:part_of" },
+      { object_type: "goal", object_id: "first-use-guide" },
+      { object_type: "goal", object_id: "tree-root" },
+    ],
+  );
+  assert.deepEqual(
+    submitted.proposal.items.find((item) => item.item_id === "item-dependency")?.affected_objects,
+    [
+      { object_type: "relation", object_id: "relation:new:first-use-guide:runtime-connection:depends_on" },
+      { object_type: "goal", object_id: "first-use-guide" },
+      { object_type: "goal", object_id: "runtime-connection" },
+    ],
+  );
+  assert.ok(submitted.proposal.items.every((item) => item.baseline_versions.length >= 1));
   assert.equal(submitted.proposal.base_event_cursor, dialogue.observed_event_cursor);
   const replay = coordinator.submitGoalTreeProposal(proposalInput);
   assert.equal(replay.replayed, true);
@@ -3548,7 +3564,12 @@ test("a clarifier submits one atomic, versioned Goal Tree proposal without touch
     actor_id: "runtime-clarifier",
     idempotency_key: "tree-proposal-check",
   });
-  assert.deepEqual(checked.conflict_item_ids, ["item-root-contract"]);
+  assert.deepEqual(checked.conflict_item_ids, [
+    "item-root-contract",
+    "item-dependency",
+    "item-candidate",
+    "item-rewire",
+  ]);
   assert.equal(
     checked.proposal.items.find((item) => item.item_id === "item-root-contract")?.state,
     "conflict",
@@ -6223,6 +6244,242 @@ test("Goal Tree decisions keep independent items, conflicts, cycles, and short c
   );
   assert.equal(store.getGoal("ambiguity-a-goal"), null);
   assert.equal(store.getGoal("ambiguity-b-goal"), null);
+  store.close();
+});
+
+test("whole Goal Tree confirmation preflights invariants and never leaves a partial tree", () => {
+  const buildInvalidProposal = () => {
+    const fixtureResult = fixture();
+    const { store, coordinator } = fixtureResult;
+    createAcceptedCompoundParent(coordinator, "atomic-confirm-parent");
+    const dialogue = coordinator.startDraftDialogue({
+      board_id: "board-1",
+      actor_id: "runtime-atomic-confirm",
+      rough_idea: "一次确认整份 Goal Tree 时，任何冲突都不能留下半棵树。",
+      goal_id: "atomic-confirm-context",
+      idempotency_key: "atomic-confirm-dialogue",
+    });
+    const proposal = coordinator.submitGoalTreeProposal({
+      board_id: "board-1",
+      actor_id: "runtime-atomic-confirm",
+      discovered_in_run_id: dialogue.run!.run_id,
+      root_goal_id: "atomic-confirm-context",
+      summary: "新增一个安全子 Goal，同时错误地改写已接受父 Goal 的 Contract。",
+      items: [
+        goalTreeProposalItem({
+          item_id: "atomic-safe-child",
+          kind: "goal",
+          operation: "create",
+          payload: treeGoalPayload({
+            goal_id: "atomic-confirm-child",
+            title: "本不应被单独创建的安全子 Goal",
+            definition_state: "draft",
+            decomposition_state: "abstract",
+          }),
+          object_type: "goal",
+          object_id: "atomic-confirm-child",
+        }),
+        goalTreeProposalItem({
+          item_id: "atomic-invalid-contract",
+          kind: "contract",
+          operation: "update",
+          payload: treeGoalPayload({
+            goal_id: "atomic-confirm-parent",
+            title: "试图改写已接受父 Goal",
+            definition_state: "accepted",
+            decomposition_state: "frontier_open",
+          }),
+          object_type: "goal",
+          object_id: "atomic-confirm-parent",
+        }),
+      ],
+      idempotency_key: "atomic-confirm-submit",
+    }).proposal;
+    return { store, coordinator, proposal };
+  };
+
+  const checkedFixture = buildInvalidProposal();
+  const cursorBeforeCheck = checkedFixture.store.snapshot("board-1").cursor;
+  const checked = checkedFixture.coordinator.checkGoalTreeProposal({
+    board_id: "board-1",
+    proposal_id: checkedFixture.proposal.proposal_id,
+    actor_id: "runtime-atomic-confirm",
+    idempotency_key: "atomic-confirm-check",
+  });
+  assert.deepEqual(checked.conflict_item_ids, ["atomic-invalid-contract"]);
+  assert.equal(checked.proposal.items.find((item) => item.item_id === "atomic-invalid-contract")?.conflict?.code,
+    "goal.accepted_compound_closure_invalid");
+  assert.equal(checked.observed_event_cursor, cursorBeforeCheck + 1);
+  assert.equal(checkedFixture.store.getGoal("atomic-confirm-child"), null);
+  checkedFixture.store.close();
+
+  const decidedFixture = buildInvalidProposal();
+  assert.throws(
+    () => decidedFixture.coordinator.decideGoalTreeProposal({
+      board_id: "board-1",
+      proposal_id: decidedFixture.proposal.proposal_id,
+      runtime_actor_id: "runtime-atomic-confirm",
+      authority: {
+        actor_id: "user-1",
+        actor_kind: "user",
+        authority_source: "runtime_dialogue",
+        conversation_ref: "conversation://atomic-confirm",
+        message_ref: "message://atomic-confirm",
+        whole_confirmation_prompted: true,
+      },
+      reason: "确认整份提案。",
+      confirm_all_pending: true,
+      idempotency_key: "atomic-confirm-decide",
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof GoalBoardV1Error);
+      assert.equal(error.code, "goal_tree_proposal.whole_confirmation_conflict");
+      assert.match(error.message, /没有写入任何变更/);
+      assert.match(error.message, /atomic-invalid-contract/);
+      return true;
+    },
+  );
+  assert.equal(decidedFixture.store.getGoal("atomic-confirm-child"), null);
+  const unchanged = decidedFixture.coordinator.listGoalTreeProposals({
+    board_id: "board-1",
+    proposal_id: decidedFixture.proposal.proposal_id,
+    include_legacy: false,
+  }).proposals[0]!;
+  assert.equal(unchanged.state, "pending");
+  assert.ok(unchanged.items.every((item) => item.state === "pending" && item.decision == null));
+  decidedFixture.store.close();
+
+  const partialFixture = buildInvalidProposal();
+  const partial = partialFixture.coordinator.decideGoalTreeProposal({
+    board_id: "board-1",
+    proposal_id: partialFixture.proposal.proposal_id,
+    runtime_actor_id: "runtime-atomic-confirm",
+    authority: {
+      actor_id: "user-1",
+      actor_kind: "user",
+      authority_source: "runtime_dialogue",
+      conversation_ref: "conversation://atomic-confirm-partial",
+      message_ref: "message://atomic-confirm-partial-item",
+    },
+    decisions: [{ item_id: "atomic-safe-child", decision: "confirm", reason: "先逐项采用安全条目。" }],
+    idempotency_key: "atomic-confirm-partial-item",
+  });
+  assert.equal(partial.proposal.state, "partially_applied");
+  assert.throws(
+    () => partialFixture.coordinator.decideGoalTreeProposal({
+      board_id: "board-1",
+      proposal_id: partialFixture.proposal.proposal_id,
+      runtime_actor_id: "runtime-atomic-confirm",
+      authority: {
+        actor_id: "user-1",
+        actor_kind: "user",
+        authority_source: "runtime_dialogue",
+        conversation_ref: "conversation://atomic-confirm-partial",
+        message_ref: "message://atomic-confirm-partial-whole",
+        whole_confirmation_prompted: true,
+      },
+      reason: "再确认剩余内容。",
+      confirm_all_pending: true,
+      idempotency_key: "atomic-confirm-partial-whole",
+    }),
+    (error: unknown) =>
+      error instanceof GoalBoardV1Error &&
+      error.code === "goal_tree_proposal.whole_confirmation_requires_pristine_proposal",
+  );
+  partialFixture.store.close();
+});
+
+test("Goal Tree baselines ignore unrelated Goal runtime state but retain Contract and relation endpoint facts", () => {
+  const { store, coordinator } = fixture();
+  const dialogue = coordinator.startDraftDialogue({
+    board_id: "board-1",
+    actor_id: "runtime-semantic-baseline",
+    rough_idea: "等待用户确认期间，租约等运行态变化不能让 Contract 提案自然过期。",
+    goal_id: "semantic-baseline-root",
+    idempotency_key: "semantic-baseline-dialogue",
+  });
+  const proposal = coordinator.submitGoalTreeProposal({
+    board_id: "board-1",
+    actor_id: "runtime-semantic-baseline",
+    discovered_in_run_id: dialogue.run!.run_id,
+    root_goal_id: "semantic-baseline-root",
+    summary: "更新 Draft Contract 并把新子 Goal 归入根 Goal。",
+    items: [
+      goalTreeProposalItem({
+        item_id: "semantic-root-contract",
+        kind: "contract",
+        operation: "update",
+        payload: treeGoalPayload({
+          goal_id: "semantic-baseline-root",
+          title: "等待确认的语义化 Draft Contract",
+          definition_state: "draft",
+          decomposition_state: "abstract",
+        }),
+        object_type: "goal",
+        object_id: "semantic-baseline-root",
+      }),
+      goalTreeProposalItem({
+        item_id: "semantic-child",
+        kind: "goal",
+        operation: "create",
+        payload: treeGoalPayload({
+          goal_id: "semantic-baseline-child",
+          title: "等待确认的新子 Goal",
+          definition_state: "draft",
+          decomposition_state: "abstract",
+        }),
+        object_type: "goal",
+        object_id: "semantic-baseline-child",
+      }),
+      goalTreeProposalItem({
+        item_id: "semantic-part-of",
+        kind: "relation",
+        operation: "create",
+        payload: {
+          from_goal_id: "semantic-baseline-child",
+          to_goal_id: "semantic-baseline-root",
+          type: "part_of",
+          reason: "新子 Goal 属于当前 Root Draft。",
+        },
+        object_type: "relation",
+        object_id: "relation:new:semantic-child:semantic-root:part_of",
+      }),
+    ],
+    idempotency_key: "semantic-baseline-submit",
+  }).proposal;
+  assert.ok(proposal.items.flatMap((item) => item.baseline_versions).every((baseline) =>
+    baseline.version === "absent" || baseline.version.startsWith("semantic-v1:")));
+  assert.deepEqual(
+    proposal.items.find((item) => item.item_id === "semantic-part-of")?.affected_objects,
+    [
+      { object_type: "relation", object_id: "relation:new:semantic-child:semantic-root:part_of" },
+      { object_type: "goal", object_id: "semantic-baseline-child" },
+      { object_type: "goal", object_id: "semantic-baseline-root" },
+    ],
+  );
+
+  store.db
+    .prepare("UPDATE goals SET fulfillment_state = 'satisfied', updated_at = ? WHERE goal_id = ?")
+    .run("2026-08-15T00:30:00.000Z", "semantic-baseline-root");
+  const runtimeOnlyCheck = coordinator.checkGoalTreeProposal({
+    board_id: "board-1",
+    proposal_id: proposal.proposal_id,
+    actor_id: "runtime-semantic-baseline",
+    idempotency_key: "semantic-baseline-runtime-check",
+  });
+  assert.deepEqual(runtimeOnlyCheck.conflict_item_ids, []);
+
+  store.db
+    .prepare("UPDATE goals SET title = ?, updated_at = ? WHERE goal_id = ?")
+    .run("真正改变 Contract 的另一个标题", "2026-08-15T00:31:00.000Z", "semantic-baseline-root");
+  const contractCheck = coordinator.checkGoalTreeProposal({
+    board_id: "board-1",
+    proposal_id: proposal.proposal_id,
+    actor_id: "runtime-semantic-baseline",
+    idempotency_key: "semantic-baseline-contract-check",
+  });
+  assert.deepEqual(contractCheck.conflict_item_ids, ["semantic-root-contract"]);
+  assert.equal(contractCheck.proposal.items.find((item) => item.item_id === "semantic-part-of")?.state, "pending");
   store.close();
 });
 

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -2765,7 +2765,7 @@ test("Web lets a user set an accepted Goal as the current Goal without starting 
   }
 });
 
-test("Web optionally uses the same Goal Tree decision path without enabling ambiguous whole confirmation", async () => {
+test("Web uses the named Goal Tree decision page for atomic whole confirmation", async () => {
   const directory = mkdtempSync(join(tmpdir(), "goalboard-web-tree-decision-"));
   const databasePath = join(directory, "goalboard.db");
   const store = new SqliteGoalBoardStore(databasePath);
@@ -2822,6 +2822,31 @@ test("Web optionally uses the same Goal Tree decision path without enabling ambi
     ],
     idempotency_key: "web-tree-propose",
   }).proposal;
+  const otherDialogue = coordinator.startDraftDialogue({
+    board_id: "web-tree-board",
+    actor_id: "runtime-other-clarifier",
+    goal_id: "web-tree-other-root",
+    rough_idea: "另一份同时等待决定的方案不能让当前 Web 页面确认变得含糊。",
+    idempotency_key: "web-tree-other-dialogue",
+  });
+  const otherProposal = coordinator.submitGoalTreeProposal({
+    board_id: "web-tree-board",
+    actor_id: "runtime-other-clarifier",
+    discovered_in_run_id: otherDialogue.run!.run_id,
+    root_goal_id: "web-tree-other-root",
+    summary: "另一份独立等待决定的方案。",
+    items: [{
+      item_id: "web-tree-other-child",
+      kind: "goal",
+      operation: "create",
+      payload: { goal_id: "web-tree-other-child", title: "另一份方案里的 Draft" },
+      source_refs: ["conversation://web-tree-other"],
+      reason: "验证 Web 页面按明确 proposal_id 原子确认，而不是依赖全局唯一提案。",
+      confidence: 1,
+      affected_objects: [{ object_type: "goal", object_id: "web-tree-other-child" }],
+    }],
+    idempotency_key: "web-tree-other-propose",
+  }).proposal;
   store.close();
   const server = createGoalBoardWebServer({ databasePath, boardId: "web-tree-board" });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -2846,6 +2871,7 @@ test("Web optionally uses the same Goal Tree decision path without enabling ambi
     assert.match(decisionPage, /展开查看每项变化/);
     assert.match(decisionPage, /data-goal-tree-decision-form[\s\S]*novalidate/);
     assert.match(WORKBENCH_CLIENT_SCRIPT, /goalTreeDecisionForm[\s\S]*请填写决定理由或修改意见/);
+    assert.match(WORKBENCH_CLIENT_SCRIPT, /decision === "confirm"[\s\S]*confirm_all_pending: true/);
     assert.match(rootPage, /查看并决定这份方案/);
     assert.match(rootPage, /处理 1 项决定/);
     assert.match(rootPage, /goal-status--clarification_decision_pending[^>]*[\s\S]*?<span>待你确认<\/span>/);
@@ -2853,16 +2879,6 @@ test("Web optionally uses the same Goal Tree decision path without enabling ambi
     assert.match(rootPage, /这条 Goal 不是还要继续澄清，而是在等你确认整理后的结果、范围和子 Goal/);
     assert.doesNotMatch(rootPage, /<div class="draft-gaps"><div><strong>这条 Goal 还没说清楚/);
     assert.doesNotMatch(rootPage, /<div class="goal-purpose">/);
-    const ambiguous = await webFetch(
-      `${origin}/api/goal-tree-proposals/${encodeURIComponent(proposal.proposal_id)}/decision`,
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ confirm_all_pending: true, reason: "确认" }),
-      },
-    );
-    assert.equal(ambiguous.status, 400);
-    assert.match(await ambiguous.text(), /不能验证上一轮/);
     const blankSubjectiveRejection = await webFetch(
       `${origin}/api/goal-tree-proposals/${encodeURIComponent(proposal.proposal_id)}/decision`,
       {
@@ -2883,18 +2899,8 @@ test("Web optionally uses the same Goal Tree decision path without enabling ambi
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          decisions: [
-            {
-              item_id: "web-tree-child",
-              decision: "confirm",
-              reason: "用户从可选 Web 页面确认保留这个 Draft 分支。",
-            },
-            {
-              item_id: "web-tree-child-relation",
-              decision: "confirm",
-              reason: "用户确认这条新工作属于当前 Goal。",
-            },
-          ],
+          confirm_all_pending: true,
+          reason: "用户在这份方案的 Web 决定页采用整份变更。",
           idempotency_key: "web-tree-decide",
         }),
       },
@@ -2919,14 +2925,176 @@ test("Web optionally uses the same Goal Tree decision path without enabling ambi
     const persisted = board.snapshot.goal_tree_proposals.find((item) => item.proposal_id === proposal.proposal_id);
     assert.equal(persisted?.items[0]?.decision?.authority_source, "web");
     assert.equal(persisted?.items[0]?.decision?.actor_id, "web-user");
+    const otherPersisted = board.snapshot.goal_tree_proposals.find(
+      (item) => item.proposal_id === otherProposal.proposal_id,
+    );
+    assert.ok(otherPersisted?.items.every((item) => item.decision === null));
     const updatedRootPage = await (await webFetch(`${origin}/goals/web-tree-root`)).text();
-    assert.match(updatedRootPage, /goal-status--clarifying[^>]*[\s\S]*?<span>目标澄清中<\/span>/);
-    assert.doesNotMatch(updatedRootPage, /<span class="goal-status goal-status--clarification_decision_pending"/);
+    const updatedRootStart = updatedRootPage.indexOf('<article class="goal-document" data-goal-view="web-tree-root"');
+    assert.ok(updatedRootStart >= 0);
+    const updatedRootHeaderEnd = updatedRootPage.indexOf("</header>", updatedRootStart);
+    assert.ok(updatedRootHeaderEnd >= 0);
+    const updatedRootDocument = updatedRootPage.slice(updatedRootStart, updatedRootHeaderEnd);
+    assert.match(updatedRootDocument, /goal-status--clarifying[^>]*[\s\S]*?<span>目标澄清中<\/span>/);
+    assert.doesNotMatch(updatedRootDocument, /goal-status--clarification_decision_pending/);
     const resultPage = await (await webFetch(`${origin}/decisions`)).text();
     assert.match(resultPage, /最近处理结果/);
     assert.match(resultPage, /Goal 方案/);
     assert.match(resultPage, /已采用 2 项变化/);
-    assert.match(resultPage, /用户从可选 Web 页面确认保留这个 Draft 分支/);
+    assert.match(resultPage, /用户在这份方案的 Web 决定页采用整份变更/);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
+test("Web explains a materialization conflict before the user confirms a whole Goal Tree proposal", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "goalboard-web-tree-preflight-"));
+  const databasePath = join(directory, "goalboard.db");
+  const store = new SqliteGoalBoardStore(databasePath);
+  const coordinator = new GoalBoardCoordinator(store);
+  coordinator.initializeBoard({
+    board_id: "web-tree-preflight-board",
+    title: "Web Tree Preflight",
+    actor_id: "web-user",
+    idempotency_key: "web-tree-preflight-init",
+  });
+  coordinator.createGoal(
+    "web-tree-preflight-board",
+    {
+      goal_id: "web-tree-accepted-parent",
+      title: "已经接受的父 Goal",
+      outcome: "保留已经确认的业务承诺",
+      why: "避免历史执行和验收对应的 Contract 被静默改写",
+      business_logic: "需求变化需要 successor，原 Goal 只允许明确的拆分收口。",
+      in_scope: ["保留已接受 Contract"],
+      out_of_scope: ["不原地重写业务承诺"],
+      required_inputs: ["用户已经接受的 Contract"],
+      promised_outputs: ["可追溯的原业务承诺"],
+      definition_state: "accepted",
+      decomposition_state: "abstract",
+      acceptance_criteria: [{
+        criterion_id: "web-tree-accepted-parent-contract",
+        statement: "原业务承诺保持可追溯",
+        decision_method: "inspection",
+        pass_condition: "已接受 Contract 不被原地改写",
+      }],
+    },
+    { actor_id: "web-user", idempotency_key: "web-tree-accepted-parent-create" },
+  );
+  const dialogue = coordinator.startDraftDialogue({
+    board_id: "web-tree-preflight-board",
+    actor_id: "runtime-tree-preflight",
+    goal_id: "web-tree-preflight-context",
+    rough_idea: "需求变化后尝试改写一个已经接受的父 Goal。",
+    idempotency_key: "web-tree-preflight-dialogue",
+  });
+  const proposal = coordinator.submitGoalTreeProposal({
+    board_id: "web-tree-preflight-board",
+    actor_id: "runtime-tree-preflight",
+    discovered_in_run_id: dialogue.run!.run_id,
+    root_goal_id: "web-tree-preflight-context",
+    summary: "错误示例：原地改写已接受父 Goal，而不是创建 successor。",
+    items: [
+      {
+        item_id: "web-tree-safe-child",
+        kind: "goal",
+        operation: "create",
+        payload: {
+          goal_id: "web-tree-safe-child",
+          title: "不能被半途创建的安全子 Goal",
+        },
+        source_refs: ["conversation://web-tree-preflight"],
+        reason: "验证整份确认失败时安全条目也不会单独落地。",
+        confidence: 1,
+        affected_objects: [{ object_type: "goal", object_id: "web-tree-safe-child" }],
+      },
+      {
+        item_id: "web-tree-invalid-accepted-update",
+        kind: "contract",
+        operation: "update",
+        payload: {
+          goal_id: "web-tree-accepted-parent",
+          title: "试图覆盖的全新业务承诺",
+          outcome: "把新需求写回旧 Goal",
+          why: "错误示例",
+          business_logic: "错误示例",
+          in_scope: ["新需求"],
+          out_of_scope: [],
+          required_inputs: ["新需求"],
+          promised_outputs: ["新结果"],
+          definition_state: "accepted",
+          decomposition_state: "frontier_open",
+          acceptance_criteria: [{
+            criterion_id: "web-tree-accepted-parent-contract",
+            statement: "新需求已经覆盖旧承诺",
+            decision_method: "inspection",
+            pass_condition: "错误示例",
+          }],
+        },
+        source_refs: ["conversation://web-tree-preflight"],
+        reason: "验证用户确认前能看到不可应用原因。",
+        confidence: 1,
+        affected_objects: [{ object_type: "goal", object_id: "web-tree-accepted-parent" }],
+      },
+    ],
+    idempotency_key: "web-tree-preflight-propose",
+  }).proposal;
+  const checked = coordinator.checkGoalTreeProposal({
+    board_id: "web-tree-preflight-board",
+    proposal_id: proposal.proposal_id,
+    actor_id: "runtime-tree-preflight",
+    idempotency_key: "web-tree-preflight-check",
+  });
+  assert.deepEqual(checked.conflict_item_ids, ["web-tree-invalid-accepted-update"]);
+  store.close();
+
+  const server = createGoalBoardWebServer({ databasePath, boardId: "web-tree-preflight-board" });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const origin = `http://127.0.0.1:${address.port}`;
+    const page = await (await webFetch(`${origin}/decisions`)).text();
+    assert.match(page, /这份方案暂时不能采用/);
+    assert.match(page, /当前有内容不满足 GoalBoard 的写入规则，修正前不会写入 Goal Tree/);
+    assert.doesNotMatch(page, /其中有风险信息或 Goal 拆解需要 Runtime 修正/);
+    assert.match(page, /已接受父 Goal 只能从 abstract 或 frontier_open 收口为 closed_compound/);
+    assert.match(page, /创建 successor \/ replacement Goal/);
+    assert.match(page, /当前 Goal Tree 尚未改变/);
+    assert.match(page, /value="confirm" disabled aria-disabled="true"/);
+    assert.match(page, /value="reject">退回修正/);
+    const directWholeConfirmation = await webFetch(
+      `${origin}/api/goal-tree-proposals/${encodeURIComponent(proposal.proposal_id)}/decision`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          confirm_all_pending: true,
+          reason: "即使直接调用 Web 接口，也必须保证整份方案原子落地。",
+          idempotency_key: "web-tree-preflight-atomic-decision",
+        }),
+      },
+    );
+    assert.equal(directWholeConfirmation.status, 400);
+    const directError = await directWholeConfirmation.text();
+    assert.match(directError, /本次整份确认没有写入任何变更/);
+    assert.match(directError, /创建 successor \/ replacement Goal/);
+    const board = (await (await webFetch(`${origin}/api/board`)).json()) as {
+      snapshot: {
+        goals: Array<{ goal_id: string }>;
+        goal_tree_proposals: Array<{
+          proposal_id: string;
+          state: string;
+          items: Array<{ state: string; decision: unknown }>;
+        }>;
+      };
+    };
+    assert.equal(board.snapshot.goals.some((goal) => goal.goal_id === "web-tree-safe-child"), false);
+    const stored = board.snapshot.goal_tree_proposals.find((item) => item.proposal_id === proposal.proposal_id);
+    assert.equal(stored?.state, "pending");
+    assert.equal(stored?.items.some((item) => item.decision != null), false);
   } finally {
     await new Promise<void>((resolve, reject) =>
       server.close((error) => (error ? reject(error) : resolve())),


### PR DESCRIPTION
修复 GB-20260829-18。\n\n- 整份确认改为全有或全无，逐项决定仍保留独立落地语义\n- goal_tree_check 复用真实 materialization 不变量并回滚预检写入\n- baseline 只覆盖条目相关业务事实，排除租约和时间戳等运行态\n- Web 展示具体冲突、恢复建议并禁用不可采用方案\n- relation/dependency 自动纳入两端 Goal 的并发基准\n\n验证：pnpm test 278/278；源码 Web 18 项整份确认 18/18 落地，非法 Contract 方案零写入；最终安装 App 验收待统一发布后完成。