### PR TITLE
release: GoalBoard v0.1.13

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1156,7 +1156,7 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "goalboard-desktop"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "portable-pty",
  "semver",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goalboard-desktop"
-version = "0.1.12"
+version = "0.1.13"
 description = "GoalBoard macOS App: WebView plus local TUI PTY"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GoalBoard",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "identifier": "com.adeptify.goalboard",
   "build": {
     "frontendDist": "../webview-placeholder"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adeptify/goalboard",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "GoalBoard V1：面向人和 AI Runtime 的本地 SQLite 目标真相源",
   "type": "module",
   "license": "MIT",

--- a/specs/session-workspace-redesign/work-items/session-content-runtime-load/qa.md
+++ b/specs/session-workspace-redesign/work-items/session-content-runtime-load/qa.md
@@ -45,6 +45,15 @@
 - `tests/web.test.ts tests/desktop-tui.test.ts`：81/82 通过。唯一失败是既有 Feed 窄屏 CSS 字符串断言 `tests/web.test.ts:1884`，检查的是 `.feed-detail` padding，与本 Work Item 的 Session 代码、API 和页面无关；没有修改该旧断言或 Feed 样式来制造通过。
 - `git diff --check`：通过。
 
+## 0.1.13 安装回归（2026-08-31）
+
+- 先安装 0.1.12 后，真实 Registry 仍保留当前 Codex Session、Project 与 `session-content-runtime-load` Goal 关系，但原生内容返回 `content_mode=failed`；这证明不是 Session 数据丢失，而是 Runtime transport 不可用。
+- 根因是受管 macOS LaunchAgent 的 `PATH` 没有包含 `~/.local/bin`，而本机 Codex CLI 位于该用户级目录。0.1.13 将该目录加入 GoalBoard 自己生成的 plist，并保留旧 plist 的 `needs_repair → 确认 install` 安全升级流程；未知 plist 仍不会被覆盖。
+- 本机安装 0.1.13 并确认修复服务后，`service status` 为 `running/owned=true`，`/health` 保持 10 个项目；当前 Session 的同一 `session_id`、原生 Runtime Session ID 和 Goal 关系均未变化。
+- 同一条当前 Session 再次读取为 `content_mode=native`、`native_error=null`，共返回 6,042 个事件：60 条用户消息、318 条 Runtime 消息、2,425 条工具记录、343 个 Artifact，其余为状态与一条 GoalBoard 关系事件。没有修改或重建 Session 数据。
+- Codex、Claude Code 与 Grok Build 的受管 Skill/MCP 接入均事务式对齐到 0.1.13 并返回 `connected`；当前已运行的 Codex Session 没有被重启，新的 Runtime Session 才会加载新 Skill/MCP 清单。
+- 第一次完整 TypeScript 门禁中，既有 300 Goal 性能断言在全套并行负载下耗时 106.1ms，超过 100ms 阈值；单独复跑为 8.7ms。系统负载恢复后再次完整运行，最终 **401/401** 通过，Session Web 同样通过。Desktop Rust 12/12、Rust format、版本一致性和 `git diff --check` 通过。
+
 ## 验收结论
 
 1. Goal TUI 内容可持久恢复并准确关联 project / Goal / Session：通过。

--- a/specs/session-workspace-redesign/work-items/session-content-runtime-load/spec.md
+++ b/specs/session-workspace-redesign/work-items/session-content-runtime-load/spec.md
@@ -21,6 +21,7 @@
 - Session 内容密文存储：TUI/GoalBoard 管理内容以 AES-256-GCM 加密文件保存，SQLite 只保存引用与无敏感正文的结构元数据。
 - PTY 输出与退出状态采集：panel spawn 明确携带 `session_id`；写入以 session 为边界，重启后仍可读取。
 - Codex app-server stdio transport：初始化、请求关联、事件订阅、超时、退出与关闭；不会把请求正文或凭据写入日志。
+- macOS 常驻 Web 的受管 PATH 必须包含用户级工具目录 `~/.local/bin`，使通过官方用户级入口安装的 Codex CLI 在 LaunchAgent 中也可被原生内容 transport 找到；只扩展 GoalBoard 自己生成的 plist，不读取或改写 Session 数据。
 - 内容服务：按 GoalBoard `session_id` 查 owning Runtime/native ID，调用 Adapter read，标准化结构化历史并与 GoalBoard 事件合并。
 - Goal 生命周期回写：Runtime 成功选择、推进或完成 Goal 时，把当前 Goal 与最小状态事件写回 owning Session；不复制 MCP 请求正文。
 - 同 Runtime resume：只向拥有该 Session 的 Adapter 发送其原生 ID；unsupported/failed 返回结构化恢复动作。
@@ -82,6 +83,7 @@ Codex 映射：
 - `src/sessions/registry.ts`：schema v1→v2 迁移和 Session event 索引事务。
 - `src/sessions/content.ts`：Runtime 响应标准化、合并、当前内容搜索和 resume 结果。
 - `src/sessions/codex-transport.ts`：Codex app-server 子进程协议边界。
+- `src/install/web-service.ts`：为 GoalBoard 自己的 LaunchAgent 提供可复现且最小的 Runtime CLI 查找 PATH。
 - `src/web/pty-host.ts` / `pty-socket.ts` / `pty-client.ts`：显式传递 session identity 并采集输出/退出。
 - `src/web/server.ts`：项目隔离的 Session content/resume API，服务生命周期与 transport 注入。
 - `src/web/project-session-workspaces.ts`：现有高密度详情使用真实记录和 API；不新增另一套导航或容器层级。
@@ -95,6 +97,7 @@ Codex 映射：
 5. 详情 API 按 project/session 双重隔离；搜索只作用于已经加载的当前 Session 内容。
 6. Session 详情移除静态“演示完成”行为，真实展示 native/fallback/unavailable/failed 与重试/恢复入口。
 7. Runtime 选择或推进 Goal 后，对应 Session 的 `current_goal_id`、Goal 历史和 GoalBoard 状态事件可被项目详情读取；同一个幂等调用不会生成重复事件。
+8. Codex CLI 只位于 `~/.local/bin` 时，确认修复受管 LaunchAgent 后，Web 仍能启动 `codex app-server` 并读取原生 Session 内容；旧 plist 被识别为 `needs_repair`，未知 plist 仍不接管。
 
 ## 验证命令
 
@@ -103,6 +106,7 @@ pnpm typecheck
 node --import tsx --test tests/session-content.test.ts tests/session-resume.test.ts tests/session-tui-capture.test.ts tests/session-content-privacy.test.ts
 node --import tsx --test tests/session-registry.test.ts tests/session-migration.test.ts tests/session-adapters.test.ts
 node --import tsx --test tests/web.test.ts tests/desktop-tui.test.ts
+node --import tsx --test tests/service.test.ts
 pnpm build
 git diff --check
 ```

--- a/src/feed/sources/runtime.ts
+++ b/src/feed/sources/runtime.ts
@@ -29,7 +29,7 @@ import {
 } from "./rss-http.js";
 
 const APP_ID = "goalboard";
-const APP_VERSION = "0.1.12";
+const APP_VERSION = "0.1.13";
 const MAX_FEED_BYTES = 2 * 1024 * 1024;
 const MAX_REDIRECTS = 2;
 

--- a/src/install/web-service.ts
+++ b/src/install/web-service.ts
@@ -306,6 +306,7 @@ export class GoalBoardWebServiceManager {
     const args = this.command().map((value) => `      <string>${escapeXml(value)}</string>`).join("\n");
     const servicePath = [
       path.dirname(this.nodeExecutablePath),
+      path.join(this.userHomeDirectory, ".local", "bin"),
       "/opt/homebrew/bin",
       "/usr/local/bin",
       "/usr/bin",

--- a/src/sessions/codex-transport.ts
+++ b/src/sessions/codex-transport.ts
@@ -77,7 +77,7 @@ export class CodexAppServerTransport implements RuntimeSessionTransport {
     child.stderr.on("data", () => undefined);
 
     await this.requestRaw("initialize", {
-      clientInfo: { name: "goalboard-session-browser", title: "GoalBoard", version: "0.1.12" },
+      clientInfo: { name: "goalboard-session-browser", title: "GoalBoard", version: "0.1.13" },
       capabilities: {
         experimentalApi: false,
         requestAttestation: false,

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -135,6 +135,7 @@ test("macOS LaunchAgent preview is read-only and confirmed install is persistent
     assert.match(plist, /<key>KeepAlive<\/key><true\/>/);
     assert.match(plist, /<key>EnvironmentVariables<\/key>/);
     assert.match(plist, new RegExp(dirname(process.execPath).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.match(plist, new RegExp(join(item.userHome, ".local", "bin").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.match(plist, new RegExp(item.home.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.match(plist, /web-service\.log/);
     assert.match(plist, /web-service\.error\.log/);


### PR DESCRIPTION
## 修复\n- 让受管 macOS LaunchAgent 的 PATH 包含 ~/.local/bin\n- 恢复 Web 对真实 Codex Session 原生内容的读取\n- 保留旧 plist 的 needs_repair 安全升级和未知配置保护\n\n## 验证\n- pnpm test: 401/401\n- Desktop Rust: 12/12，cargo fmt 通过\n- 当前真实 Session: content_mode=native，读取 6,042 个事件\n- 本机 arm64 DMG/ZIP checksum 通过\n\n## 发布边界\n- GitHub 资产按既有 ad-hoc Prerelease 口径，不冒充 Apple 公证包